### PR TITLE
Update subdivisions of iso:code:3166:TW

### DIFF
--- a/src/pycountry/databases/iso3166-2.json
+++ b/src/pycountry/databases/iso3166-2.json
@@ -23363,117 +23363,112 @@
     {
       "code": "TW-CHA",
       "name": "Changhua",
-      "type": "District"
+      "type": "County"
     },
     {
       "code": "TW-CYI",
-      "name": "Chiay City",
-      "type": "Municipality"
+      "name": "Chiayi City",
+      "type": "City"
     },
     {
       "code": "TW-CYQ",
-      "name": "Chiayi",
-      "type": "District"
-    },
-    {
-      "code": "TW-HSQ",
-      "name": "Hsinchu",
-      "type": "District"
+      "name": "Chiayi County",
+      "type": "County"
     },
     {
       "code": "TW-HSZ",
-      "name": "Hsinchui City",
-      "type": "Municipality"
+      "name": "Hsinchu City",
+      "type": "City"
+    },
+    {
+      "code": "TW-HSQ",
+      "name": "Hsinchu County",
+      "type": "County"
     },
     {
       "code": "TW-HUA",
       "name": "Hualien",
-      "type": "District"
-    },
-    {
-      "code": "TW-ILA",
-      "name": "Ilan",
-      "type": "District"
-    },
-    {
-      "code": "TW-KEE",
-      "name": "Keelung City",
-      "type": "Municipality"
+      "type": "County"
     },
     {
       "code": "TW-KHH",
-      "name": "Kaohsiung City",
+      "name": "Kaohsiung",
       "type": "Special Municipality"
     },
     {
-      "code": "TW-KHQ",
-      "name": "Kaohsiung",
-      "type": "District"
+      "code": "TW-KEE",
+      "name": "Keelung",
+      "type": "City"
+    },
+    {
+      "code": "TW-KIN",
+      "name": "Kinmen",
+      "type": "County"
+    },
+    {
+      "code": "TW-LIE",
+      "name": "Lienchiang",
+      "type": "County"
     },
     {
       "code": "TW-MIA",
       "name": "Miaoli",
-      "type": "District"
+      "type": "County"
     },
     {
       "code": "TW-NAN",
       "name": "Nantou",
-      "type": "District"
+      "type": "County"
+    },
+    {
+      "code": "TW-NWT",
+      "name": "New Taipei",
+      "type": "Special Municipality"
     },
     {
       "code": "TW-PEN",
       "name": "Penghu",
-      "type": "District"
+      "type": "County"
     },
     {
       "code": "TW-PIF",
       "name": "Pingtung",
-      "type": "District"
+      "type": "County"
     },
     {
-      "code": "TW-TAO",
-      "name": "Taoyuan",
-      "type": "District"
-    },
-    {
-      "code": "TW-TNN",
-      "name": "Tainan City",
-      "type": "Municipality"
-    },
-    {
-      "code": "TW-TNQ",
-      "name": "Tainan",
-      "type": "District"
-    },
-    {
-      "code": "TW-TPE",
-      "name": "Taipei City",
+      "code": "TW-TXG",
+      "name": "Taichung",
       "type": "Special Municipality"
     },
     {
-      "code": "TW-TPQ",
+      "code": "TW-TNN",
+      "name": "Tainan",
+      "type": "Special Municipality"
+    },
+    {
+      "code": "TW-TPE",
       "name": "Taipei",
-      "type": "District"
+      "type": "Special Municipality"
     },
     {
       "code": "TW-TTT",
       "name": "Taitung",
-      "type": "District"
+      "type": "County"
     },
     {
-      "code": "TW-TXG",
-      "name": "Taichung City",
-      "type": "Municipality"
+      "code": "TW-TAO",
+      "name": "Taoyuan",
+      "type": "Special Municipality"
     },
     {
-      "code": "TW-TXQ",
-      "name": "Taichung",
-      "type": "District"
+      "code": "TW-ILA",
+      "name": "Yilan",
+      "type": "County"
     },
     {
       "code": "TW-YUN",
       "name": "Yunlin",
-      "type": "District"
+      "type": "County"
     },
     {
       "code": "TZ-01",


### PR DESCRIPTION
Update subdivisions of iso:code:3166:TW according to https://www.iso.org/obp/ui/#iso:code:3166:TW
Includes ISO changes:
2016-11-15: Change of subdivision category from municipality to city and district to county; update
2015-11-27: Addition of category name for special municipality in zho; change of spelling of TW-ILA;
deletion of districts TW-KHQ, TW-TNQ, TW-TPQ, TW-TXQ; addition of districts TW-KIN,TW-LIE and special municipality TW-NWT; change of subdivision category from municipalities to special municipalities for TW-TXG, TW-TNN; change of subdivision category from district to special municipality for TW-TAO