### PR TITLE
Use the translation table just for a specific translation instead of …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,8 +270,7 @@ Here is an example translating language names:
   >>> import gettext
   >>> german = gettext.translation('iso3166', pycountry.LOCALES_DIR,
   ...                              languages=['de'])
-  >>> german.install()
-  >>> _('Germany')
+  >>> german.gettext('Germany')
   'Deutschland'
 
 Lookups


### PR DESCRIPTION
…installing it globally. Note: tested on python 3.5.3. `pycountry` import left out intentionally