### PR TITLE
Add translations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,24 @@ Here is an example translating language names:
   >>> _('Germany')
   'Deutschland'
 
+It is also possible to install the translations directly into pycountry, to allow for searching using alternate languages
+
+.. code:: pycon
+
+  >>> import pycountry
+  >>> pycountry.install_translations_for_countries(['de']) # german
+  >>> pycountry.countries.lookup('frankreich')
+  Country(alpha_2='FR', alpha_3='FRA', name='France', ...)
+
+Multiple languages can be installed at once.
+**Note**: Every call for `install_translations_for_countries`
+overrides previous translations
+
+.. code:: pycon
+
+  >>> import pycountry
+  >>> pycountry.install_translations_for_countries(['es', 'ar', 'de'])
+
 Lookups
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pycountry',
-    version='19.8.19.dev0',
+    version='19.9',
     author='Christian Theune',
     author_email='ct@flyingcircus.io',
     description='ISO country, subdivision, language, currency and script '

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -132,6 +132,9 @@ class Database(object):
             for v in candidate._fields.values():
                 if v is None:
                     continue
-                if v.lower() == value:
+                if isinstance(v, list):
+                    if value in v:
+                        return candidate
+                elif v.lower() == value:
                     return candidate
         raise LookupError('Could not find a record for %r' % value)

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -220,3 +220,6 @@ def test_translations():
     assert pycountry.countries.lookup('frankreich').alpha_2 == 'FR'
     assert pycountry.countries.lookup('Francia').alpha_2 == 'FR'
     assert pycountry.countries.lookup('فرنسا').alpha_2 == 'FR'
+
+    # test fuzzy
+    assert pycountry.countries.search_fuzzy('frankrei')[0].alpha_2 == 'FR'

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -213,3 +213,10 @@ def test_subdivision_empty_list():
     assert len(s.get(country_code='DE')) == 16
     assert len(s.get(country_code='JE')) == 0
     assert s.get(country_code='FOOBAR') is None
+
+
+def test_translations():
+    pycountry.install_translations_for_countries(['de', 'es', 'ar'])
+    assert pycountry.countries.lookup('frankreich').alpha_2 == 'FR'
+    assert pycountry.countries.lookup('Francia').alpha_2 == 'FR'
+    assert pycountry.countries.lookup('فرنسا').alpha_2 == 'FR'


### PR DESCRIPTION
Added support for pycountry to use its translations to lookup countries

```python
import pycountry

pycountry.install_translations_for_countries(['de', 'es',  'ar'])
```
After this line the user can search for countries using their german, spanish, and arabic name in addition to english.
```python```
pycountry.countries.lookup('frankreich') -> Returns France
```

I added the `install_translations_for_countries` method only to countries because I saw that some languages don't have translations for other stuff like subdivisions, it can be easily added by the user for anything else.

```python
def install_translations_for_subdivision(languages):
    # Add translations to subdivision
    langs = [gettext.translation('iso3166-2', LOCALES_DIR, languages=[lang]) for lang in languages]
    for subdivision in subdivision:
        subdivision.translations = [lang.gettext(subdivision.name).lower() for lang in langs]
```

I added tests and everything seems to work.