### PR TITLE
pkg_resources also throws DistributionNotFound exception here

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -10,7 +10,7 @@ try:
     import pkg_resources
     resource_filename = pkg_resources.resource_filename
     __version__ = pkg_resources.get_distribution("pycountry").version
-except ImportError:
+except (ImportError, pkg_resources.DistributionNotFound):
     __version__ = 'n/a'
 
     def resource_filename(package_or_requirement, resource_name):


### PR DESCRIPTION
pkg_resources also throws DistributionNotFound when trying to get a distribution (or perhaps it was changed from ImportError).

Since the idea is to just pop a n/a as a version number when import fails, this seems like the case.