### PR TITLE
Add repo url to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Topic :: Software Development :: Internationalization',
         'Topic :: Software Development :: Localization',
     ],
+    url='https://github.com/flyingcircusio/pycountry',
     zip_safe=False,
     packages=find_packages('src'),
     include_package_data=True,


### PR DESCRIPTION
Add repo url to setup.py to allow pypi to automatically link the pypi project page to github project page.