### PR TITLE
Add install_require on setuptools for pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Topic :: Software Development :: Localization',
     ],
     python_requires='>=3.5, <4',
+    install_requires=['setuptools'],  # pkg_resources
     zip_safe=False,
     packages=find_packages('src'),
     include_package_data=True,


### PR DESCRIPTION
While technically depending on setuptools is not required when
installing via pip, it provides useful information for distribution
packagers that need to explicitly distinguish runtime dependency
on setuptools from the usual kind of pure build-time dependency.