### PR TITLE
Add official_name for Korea

### DIFF
--- a/src/pycountry/databases/iso3166-1.json
+++ b/src/pycountry/databases/iso3166-1.json
@@ -816,7 +816,8 @@
       "alpha_2": "KR",
       "alpha_3": "KOR",
       "name": "Korea, Republic of",
-      "numeric": "410"
+      "numeric": "410",
+      "official_name": "Republic of Korea"
     },
     {
       "alpha_2": "KW",


### PR DESCRIPTION
Hi!
I found out that the official name was missing.
I'm not sure if I can just change the database like this, but hope it works!