### PR TITLE
Add Kosovo Country

### DIFF
--- a/src/pycountry/databases/iso3166-1.json
+++ b/src/pycountry/databases/iso3166-1.json
@@ -1646,6 +1646,13 @@
       "official_name": "Independent State of Samoa"
     },
     {
+      "alpha_2":"XK",
+      "alpha_3":"XKX",
+      "name": "Kosovo",
+      "numeric":"926",
+      "official_name": "Republic of Kosovo"
+    },
+    {
       "alpha_2": "YE",
       "alpha_3": "YEM",
       "name": "Yemen",


### PR DESCRIPTION
Hi,
I found out one of the country was missing from the database. 
Added the country to the database and rest of the details already exists. 

Kosovo ISO Numeric Country Code [Source]: https://www.dnb.com/content/dam/english/dnb-solutions/sales-and-marketing/iso_3digit_numeric_country_codes.xls
