### PR TITLE
Mmaroli/find subdivision within specific country

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,17 @@ The divisions of a single country can be queried using the country_code index:
   >>> len(pycountry.subdivisions.get(country_code='US'))
   57
 
+The divisions of a single country can be queried using the country index which
+returns a dictionary so we can search states in a country:
+
+.. code:: pycon
+
+  >>> len(pycountry.subdivisions.get(country='US'))
+  57
+
+  >>> pycountry.subdivisions.get(country='US')['florida']
+  Subdivision(code='US-FL', country_code='US', name='Florida', parent_code=None, type='State')
+
 
 Scripts (ISO 15924)
 -------------------

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -179,10 +179,15 @@ class Subdivisions(pycountry.db.Database):
 
         # Add index for the country code.
         self.indices['country_code'] = {}
+        # Add index for lookup by country_code and state.
+        self.indices['country'] = {}
         for subdivision in self:
             divs = self.indices['country_code'].setdefault(
                 subdivision.country_code.lower(), set())
             divs.add(subdivision)
+            country_state_mapping = self.indices['country'].setdefault(
+                subdivision.country_code.lower(), {})
+            country_state_mapping[subdivision.name.lower()] = subdivision
 
     def get(self, **kw):
         default = kw.setdefault('default', None)

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -237,3 +237,12 @@ def test_has_version_attribute():
     assert pycountry.__version__ != 'n/a'
     assert len(pycountry.__version__) >= 5
     assert '.' in pycountry.__version__
+
+
+def test_subdivision_with_country():
+    s = pycountry.subdivisions
+    assert len(s.get(country='US')) == 57
+    fl = pycountry.subdivisions.get(code='US-FL')
+    state = 'Florida'
+    assert s.get(country='US')[state.lower()] == fl
+    assert s.get(country='FOOBAR') is None


### PR DESCRIPTION
Adds functionality to find subdivisions within a country. The return value of `pycountry.subdivisions.get(country=<country>)` is a `dict` mapping a lowercased subdivision name to the subdivision object. This will solve the problem of not being able to lookup ambiguous subdivisions if a subdivision exists in multiple countries. 