### PR TITLE
Add official and common names for Republic of Korea

### DIFF
--- a/src/pycountry/databases/iso3166-1.json
+++ b/src/pycountry/databases/iso3166-1.json
@@ -815,8 +815,10 @@
     {
       "alpha_2": "KR",
       "alpha_3": "KOR",
+      "common_name": "South Korea",
       "name": "Korea, Republic of",
-      "numeric": "410"
+      "numeric": "410",
+      "official_name": "Republic of Korea"
     },
     {
       "alpha_2": "KW",


### PR DESCRIPTION
This PR like https://github.com/flyingcircusio/pycountry/pull/58, but with additional `common_name` field.