### PR TITLE
Added ROA as language

### DIFF
--- a/src/pycountry/databases/iso639-3.json
+++ b/src/pycountry/databases/iso639-3.json
@@ -34740,6 +34740,12 @@
       "type": "L"
     },
     {
+      "alpha_3": "roa",
+      "name": "Romance languages",
+      "scope": "C",
+      "type": "L"
+    },
+    {
       "alpha_3": "rob",
       "name": "Tae'",
       "scope": "I",


### PR DESCRIPTION
Add roa as language:

https://iso639-3.sil.org/code/roa

(I'm unsure with `"scope": "C"`. The ISO documentation says "Scope=Collective" - but I don't know how that translates to the enum value).