### PR TITLE
Fixed inconsistency with "ID-SB" and "ID-SS" on ISO3166-2

### DIFF
--- a/src/pycountry/databases/iso3166-2.json
+++ b/src/pycountry/databases/iso3166-2.json
@@ -10390,7 +10390,7 @@
     },
     {
       "code": "ID-SB",
-      "name": "Sumatra Barat",
+      "name": "Sumatera Barat",
       "parent": "SM",
       "type": "Province"
     },
@@ -10424,7 +10424,7 @@
     },
     {
       "code": "ID-SS",
-      "name": "Sumatra Selatan",
+      "name": "Sumatera Selatan",
       "parent": "SM",
       "type": "Province"
     },


### PR DESCRIPTION
Changing Sumatra Barat to Sumatera Barat and Sumatra Selatan to Sumatera Selatan to be consistent with parent: Sumatera