### PR TITLE
Addition of lexical resource derived from wikipedia string-matching. 

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -2,7 +2,10 @@
 """pycountry"""
 
 import os.path
+import re
 import unicodedata
+from functools import cache
+
 import pycountry.db
 
 
@@ -26,12 +29,48 @@ def remove_accents(input_str):
     nfkd_form = unicodedata.normalize('NFKD', input_str)
     return u"".join([c for c in nfkd_form if not unicodedata.combining(c)])
 
+re_nonalpha = re.compile("\W+")
+re_stopwords = re.compile("(and|or|the|of)", re.IGNORECASE)
+
+def normalize(s):
+    s = remove_accents(s.strip().lower())
+    s = re_stopwords.sub(" ", s)
+    s = re_nonalpha.sub(" ", s) # this also combines multiple spaces
+    return s
+
+
+class Country(): # this is just to make life easier for IDEs etc.
+    alpha_2:str = property()
+    alpha_3:str = property()
+    name:str = property()
+    official_name:str = property()
+    numeric:str = property()
+
 
 class ExistingCountries(pycountry.db.Database):
     """Provides access to an ISO 3166 database (Countries)."""
 
     data_class_name = 'Country'
     root_key = '3166-1'
+
+
+    @cache # this is important, otherwise it'll regenerate the database every time it's queried!
+    def wikipedia_redirects(self, aggressively_normalize=False):
+        wik_redirs = dict()
+        with open("src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.tab", "rt") as f:
+            for line in f:
+                [twoletter, displaytitle, alias] = line.strip().split("\t")
+                if aggressively_normalize:
+                    term = normalize(alias)
+                else:
+                    term = remove_accents(alias.strip().lower())
+
+                if term in wik_redirs and wik_redirs[term] != twoletter:
+                    print("clash! {} and {} both can be got to from {}")
+                else:
+                    wik_redirs[term] = twoletter
+        return(wik_redirs)
+
 
     def search_fuzzy(self, query):
         query = remove_accents(query.strip().lower())
@@ -40,15 +79,27 @@ class ExistingCountries(pycountry.db.Database):
         # based on the query's matching incidence.
         results = {}
 
-        def add_result(country, points):
-            results.setdefault(country.alpha_2, 0)
-            results[country.alpha_2] += points
+        def add_result(country, points, is_already_alpha_2 = False):
+            if is_already_alpha_2:
+                a2 = country
+            else:
+                a2 = country.alpha_2
+            results.setdefault(a2, 0)
+            results[a2] += points
 
         # Prio 1: exact matches on country names
         try:
             add_result(self.lookup(query), 50)
         except LookupError:
             pass
+
+        # Prio 1.5: exact matches on wikipedia redirect names:
+        if self.__class__ == ExistingCountries: # assuming data for historic countries not generated.
+            if query in self.wikipedia_redirects():
+                add_result(self.wikipedia_redirects()[query], 49, is_already_alpha_2=True)
+            elif normalize(query) in self.wikipedia_redirects(aggressively_normalize = True):
+                add_result(self.wikipedia_redirects(aggressively_normalize = True)[normalize(query)], 45, is_already_alpha_2=True)
+
 
         # Prio 2: exact matches on subdivision names
         for candidate in subdivisions:
@@ -60,7 +111,7 @@ class ExistingCountries(pycountry.db.Database):
                 # match exactly.
                 for v in v.split(';'):
                     if v == query:
-                        add_result(candidate.country, 49)
+                        add_result(candidate.country, 40)
                         break
 
         # Prio 3: partial matches on country names
@@ -196,7 +247,7 @@ class Subdivisions(pycountry.db.Database):
         return subdivisions
 
 
-countries = ExistingCountries(os.path.join(DATABASE_DIR, 'iso3166-1.json'))
+countries:list[Country] = ExistingCountries(os.path.join(DATABASE_DIR, 'iso3166-1.json'))
 subdivisions = Subdivisions(os.path.join(DATABASE_DIR, 'iso3166-2.json'))
 historic_countries = HistoricCountries(
     os.path.join(DATABASE_DIR, 'iso3166-3.json'))

--- a/src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.cleaned.tab
+++ b/src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.cleaned.tab
@@ -1,0 +1,1980 @@
+AW	Aruba	Aruba
+AW	Aruba	Island of Aruba
+AW	Aruba	Aruba, Aruba
+AW	Aruba	San Nicolas Zuid
+AF	Islamic Republic of Afghanistan	Islamic Republic of Afghanistan
+AF	Islamic Republic of Afghanistan	The Islamic Republic of Afghanistan
+AF	Islamic Republic of Afghanistan	Old Afghanistan
+AF	Islamic Republic of Afghanistan	Afghan Islamic Republic
+AF	Islamic Republic of Afghanistan	Afghanistan Islamic Republic
+AO	Angola	Angola
+AO	Angola	Republic of Angola
+AO	Angola	Angloa
+AO	Angola	The Republic of Angola
+AO	Angola	República de Angola
+AO	Angola	Repubilika ya Ngola
+AI	Anguilla	Anguilla
+AI	Anguilla	Anguila
+AI	Anguilla	Anguila Islands
+AX	Åland	Åland
+AX	Åland	Aland
+AX	Åland	Ahvenanmaa
+AX	Åland	AAland
+AX	Åland	Alandia
+AX	Åland	Ahvenanmaa Islands
+AX	Åland	Aland Isles
+AX	Åland	Aaland Islands
+AX	Åland	Ahvenamaa
+AL	Albania	Albania
+AL	Albania	Shqipëria
+AL	Albania	Republic of Albania
+AL	Albania	Arbania
+AL	Albania	Shqiperia
+AL	Albania	Shquiperia
+AL	Albania	Albanie
+AL	Albania	Republika e Shqipërisë
+AL	Albania	Shqiperi
+AL	Albania	Shqipëri
+AD	Andorra	Andorra
+AD	Andorra	AndorrA
+AD	Andorra	Principat d'Andorra
+AD	Andorra	Principauté d'Andorre
+AD	Andorra	Principado de Andorra
+AD	Andorra	Andorran Demographics
+AD	Andorra	Andorre
+AE	United Arab Emirates	United Arab Emirates
+AE	United Arab Emirates	United Arab Emirate
+AE	United Arab Emirates	United Emirates
+AE	United Arab Emirates	Al-Imarat Al-Arabiyah Al-Muttahidah
+AE	United Arab Emirates	United arab
+AE	United Arab Emirates	United arabic
+AE	United Arab Emirates	U.A.E.
+AE	United Arab Emirates	The United Arab Emirates
+AE	United Arab Emirates	UAE
+AE	United Arab Emirates	U.A.E
+AR	Argentina	Argentina
+AR	Argentina	Argentine Republic
+AR	Argentina	Argentine republic
+AR	Argentina	Argentinia
+AR	Argentina	República Argentina
+AR	Argentina	Nación Argentina
+AR	Argentina	Republic of Argentina
+AR	Argentina	Republica Argentina
+AR	Argentina	Land of silver
+AR	Argentina	Argentina Information
+AM	Armenia	Armenia
+AM	Armenia	Republic of Armenia
+AM	Armenia	Hayastan
+AM	Armenia	Hyester
+AM	Armenia	Հայաստանի Հանրապետություն
+AM	Armenia	Hayasdan
+AM	Armenia	Ermenistan
+AM	Armenia	Armenien
+AM	Armenia	Արմէնիա
+AM	Armenia	Armenai
+AS	American Samoa	American Samoa
+AS	American Samoa	American Samoa territory, United States
+AS	American Samoa	Samoa, American
+AS	American Samoa	East Samoa
+AS	American Samoa	Transportin American Samoa
+AQ	Antarctica	Antarctica
+AQ	Antarctica	Antartica
+AQ	Antarctica	Anartica
+AQ	Antarctica	South frigid zone
+AQ	Antarctica	Anarctica
+AQ	Antarctica	ANTARCTICA
+AQ	Antarctica	Antartcica
+TF	French Southern and Antarctic Lands	French Southern and Antarctic Lands
+TF	French Southern and Antarctic Lands	French Southern and Antarctic Territories
+TF	French Southern and Antarctic Lands	TAAF
+TF	French Southern and Antarctic Lands	Southern and Antarctic Territories
+TF	French Southern and Antarctic Lands	Terres Australes et Antarctiques Françaises Territoire
+TF	French Southern and Antarctic Lands	Terres Australes et Antarctiques Françaises Territoire, French Southern and Antarctic Lands
+TF	French Southern and Antarctic Lands	Territory of the French Southern and Antarctic Lands
+TF	French Southern and Antarctic Lands	French Southern And Antarctic Lands
+TF	French Southern and Antarctic Lands	French Southern Territories
+TF	French Southern and Antarctic Lands	French Southern and Antarctic Land
+AG	Antigua and Barbuda	Antigua and Barbuda
+AG	Antigua and Barbuda	Antigua And Barbuda
+AG	Antigua and Barbuda	Antigua & Barbuda
+AG	Antigua and Barbuda	Wadadli
+AG	Antigua and Barbuda	Antigua and barbuda
+AG	Antigua and Barbuda	Antigua-Barbuda
+AU	Australia	Australia
+AU	Australia	Commonwealth of Australia
+AU	Australia	Australian Commonwealth
+AU	Australia	Straya
+AU	Australia	Commonwealth of australia
+AU	Australia	Austrailia
+AU	Australia	Australias
+AU	Australia	Australai
+AU	Australia	Austrlaia
+AT	Austria	Austria
+AT	Austria	Österreich
+AT	Austria	Osterreich
+AT	Austria	Republic of Austria
+AT	Austria	Republik Osterreich
+AT	Austria	Austurríki
+AT	Austria	Austrian Republic
+AT	Austria	Republik Österreich
+AZ	Azerbaijan	Azerbaijan
+AZ	Azerbaijan	Azerbajdzhan
+AZ	Azerbaijan	Azerbaijani Republic
+AZ	Azerbaijan	Azerbaidzhan
+AZ	Azerbaijan	Azherbeijan
+AZ	Azerbaijan	Republic of Azerbaijan
+AZ	Azerbaijan	Azerbaijan Republic
+AZ	Azerbaijan	Republic of Azerbaijan.
+AZ	Azerbaijan	Azerbaycan
+AZ	Azerbaijan	North Azerbaijan
+BI	Burundi	Burundi
+BI	Burundi	Republic of Burundi
+BI	Burundi	Burundis
+BI	Burundi	Urundi
+BI	Burundi	The Republic of Burundi
+BI	Burundi	Burundians
+BI	Burundi	Burundia
+BI	Burundi	Republika y'Uburundi
+BI	Burundi	République du Burundi
+BI	Burundi	Imbonerakure
+BE	Belgium	Belgium
+BE	Belgium	België
+BE	Belgium	Belgien
+BE	Belgium	Belgique
+BE	Belgium	Beligum
+BE	Belgium	Kingdom of Belgium
+BJ	Benin	Benin
+BJ	Benin	Bénin
+BJ	Benin	Beninese
+BJ	Benin	Republic of Bénin
+BJ	Benin	Republic of Benin
+BJ	Benin	Benin Republic
+BQ	Caribbean Netherlands	Caribbean Netherlands
+BQ	Caribbean Netherlands	Kingdom Islands
+BQ	Caribbean Netherlands	BES Islands
+BQ	Caribbean Netherlands	Bonaire, Sint Eustatius and Saba
+BQ	Caribbean Netherlands	BES islands
+BQ	Caribbean Netherlands	Bonaire, Saint Eustatius and Saba
+BF	Burkina Faso	Burkina Faso
+BF	Burkina Faso	Burkina
+BF	Burkina Faso	Burkina Fasoan
+BF	Burkina Faso	Burkino Faso
+BF	Burkina Faso	Burkina Fasso
+BF	Burkina Faso	Burkina-Faso
+BF	Burkina Faso	Bourkina Faso
+BF	Burkina Faso	Burkina Fatso
+BF	Burkina Faso	Bourkina-Fasso
+BF	Burkina Faso	Bourkina Fasso
+BD	Bangladesh	Bangladesh
+BD	Bangladesh	Bangla Desh
+BD	Bangladesh	Bengladesh
+BD	Bangladesh	Republic of Bangladesh
+BD	Bangladesh	Blangadesh
+BD	Bangladesh	People's Republic of Bangladesh
+BD	Bangladesh	গনপ্রজাতন্ত্রী বাংলােদশ
+BD	Bangladesh	বাংলাদেশ
+BD	Bangladesh	Bangla-Desh
+BD	Bangladesh	Bangledesh
+BG	Bulgaria	Bulgaria
+BG	Bulgaria	Republic of Bulgaria
+BG	Bulgaria	Bulgarie
+BG	Bulgaria	Western Bulgaria
+BG	Bulgaria	Balgaria
+BG	Bulgaria	Булгария
+BG	Bulgaria	Balgariya
+BG	Bulgaria	Балгария
+BG	Bulgaria	Република България
+BG	Bulgaria	Bulgariya
+BH	Bahrain	Bahrain
+BH	Bahrain	Bahrein
+BH	Bahrain	Al-Bahrayn
+BH	Bahrain	Bahrain islands
+BH	Bahrain	مملكة البحرين
+BH	Bahrain	Kingdom of Bahrain
+BH	Bahrain	Bahrayn
+BH	Bahrain	Al-Baḥrayn
+BS	The Bahamas	The Bahamas
+BS	The Bahamas	Commonwealth of The Bahamas
+BS	The Bahamas	Commonwealth of the Bahamas
+BS	The Bahamas	The Commonwealth of the Bahamas
+BS	The Bahamas	The Commonwealth of The Bahamas
+BS	The Bahamas	Bahama
+BS	The Bahamas	Bahama Islands
+BS	The Bahamas	Bahamas, The
+BS	The Bahamas	Bahamas
+BA	Republic of Bosnia and Herzegovina	Republic of Bosnia and Herzegovina
+BA	Republic of Bosnia and Herzegovina	Republika Bosna i Hercegovina
+BA	Republic of Bosnia and Herzegovina	Republic of Bosnia and Hercegovina
+BA	Republic of Bosnia and Herzegovina	RBiH
+BA	Republic of Bosnia and Herzegovina	Rbih
+BA	Republic of Bosnia and Herzegovina	Republic of Bosnia & Herzegovina
+BA	Republic of Bosnia and Herzegovina	RB&H
+BA	Republic of Bosnia and Herzegovina	R B&H
+BA	Republic of Bosnia and Herzegovina	R BiH
+BA	Republic of Bosnia and Herzegovina	Republic of BiH
+BL	Saint Barthélemy	Saint Barthélemy
+BL	Saint Barthélemy	Saint Barts
+BL	Saint Barthélemy	Saint-Barthélémy
+BL	Saint Barthélemy	Saint-Barthelemy
+BL	Saint Barthélemy	St. Barthelemy
+BL	Saint Barthélemy	St. Barths
+BL	Saint Barthélemy	Saint Barths
+BL	Saint Barthélemy	Saint Barth
+BL	Saint Barthélemy	St. Barthélemy
+BL	Saint Barthélemy	St barthelemy
+BL	Saint Barthélemy	Saint Barthélémy
+BY	Belarus	Belarus
+BY	Belarus	Belorussia
+BY	Belarus	Belaruss
+BY	Belarus	Belarus'
+BY	Belarus	Belorus
+BY	Belarus	Republic of Belarus
+BY	Belarus	Belarussia
+BY	Belarus	Belarus’
+BY	Belarus	Byelarus
+BY	Belarus	Bielorussia
+BZ	Belize	Belize
+BZ	Belize	Dominion of Belize
+BZ	Belize	Belieze
+BZ	Belize	Belizian
+BZ	Belize	Beliz
+BZ	Belize	Crown Colony of Belize
+BM	Bermuda	Bermuda
+BM	Bermuda	Burmuda
+BM	Bermuda	Bermudas
+BM	Bermuda	Bermoothes
+BM	Bermuda	Bermuda Islands
+BO	Bolivia	Bolivia
+BO	Bolivia	Boliva
+BO	Bolivia	Republic of Bolivia
+BO	Bolivia	Bolívia
+BO	Bolivia	Bolivian Republic
+BO	Bolivia	República de Bolivia
+BO	Bolivia	The Plurinational State of Bolivia
+BO	Bolivia	Plurinational State of Bolivia
+BO	Bolivia	Bolivia, Plurinational State of
+BR	Brazil	Brazil
+BR	Brazil	Republic of Brazil
+BR	Brazil	Brésil
+BR	Brazil	Federative Republic of Brazil
+BR	Brazil	Federal Republic of Brazil
+BR	Brazil	Brasil
+BR	Brazil	Bresil
+BR	Brazil	República Federativa do Brasil
+BR	Brazil	Republica Federativa do Brasil
+BB	Barbados	Barbados
+BB	Barbados	Barbadoes
+BB	Barbados	Barbadan
+BB	Barbados	Barbadoes, Wisconsin
+BB	Barbados	Barbados, Wisconsin
+BB	Barbados	Barbadoes, WI
+BB	Barbados	Barbados, WI
+BN	Brunei	Brunei
+BN	Brunei	Brunei Darussalam
+BN	Brunei	Brunei Darrussalam
+BN	Brunei	Negara Brunei Darussalam
+BN	Brunei	State of Brunei, Abode of Peace
+BN	Brunei	Brunei Darsussalam
+BN	Brunei	Brunai
+BN	Brunei	State of Brunei Darussalam
+BN	Brunei	Brunei Sultanate
+BN	Brunei	برني دارالسلا
+BT	Bhutan	Bhutan
+BT	Bhutan	Druk Yul
+BT	Bhutan	Kingdom of Bhutan
+BT	Bhutan	Bootan
+BT	Bhutan	འབྲུག་ཡུལ
+BT	Bhutan	Lho Mon
+BT	Bhutan	Lho Tsendenjong
+BT	Bhutan	Lhomen Khazhi
+BT	Bhutan	Lho Men Jong
+BV	Bouvet Island	Bouvet Island
+BW	Botswana	Botswana
+BW	Botswana	Republic of Botswana
+BW	Botswana	Country BWA
+BW	Botswana	Botsuana
+BW	Botswana	Khama's Country
+BW	Botswana	Lefatshe la Botswana
+BW	Botswana	The Republic of Botswana
+CF	Central African Republic	Central African Republic
+CF	Central African Republic	CAR
+CF	Central African Republic	République Centrafricaine
+CF	Central African Republic	Centrafrique
+CF	Central African Republic	Central Africa Republic
+CF	Central African Republic	Central African republic
+CF	Central African Republic	Central african republic
+CF	Central African Republic	The Central African Republic
+CA	Canada	Canada
+CA	Canada	CANADA
+CA	Canada	Xanada
+CA	Canada	Canada.
+CA	Canada	ᑲᓇᑕ
+CA	Canada	Canadialand
+CA	Canada	Canadian Federation
+CA	Canada	Canadá
+CC	Cocos (Keeling) Islands	Keeling Islands
+CH	Switzerland	Switzerland
+CH	Switzerland	Suisse
+CH	Switzerland	Swiss Confederation
+CH	Switzerland	Schweiz
+CH	Switzerland	Svizzera
+CH	Switzerland	Confoederatio Helvetica
+CH	Switzerland	Confederaziun Svizra
+CH	Switzerland	Confederazione Svizzera
+CH	Switzerland	Confédération Suisse
+CH	Switzerland	Schweizerische Eidgenossenschaft
+CL	Chile	Chile
+CL	Chile	Republic of Chile
+CL	Chile	Chilean Republic
+CL	Chile	State of Chile
+CL	Chile	Chilé
+CL	Chile	República de Chile
+CN	China	China
+CN	China	Peoples Republic of China
+CN	China	People’s Republic of China
+CN	China	P.R.C.
+CN	China	Zhong Guo
+CN	China	Peoples' Republic of China
+CN	China	China, People's Republic of
+CN	China	Zhongguo
+CN	China	The Peoples Republic of China
+CN	China	The People's Republic of China
+CI	Ivory Coast	Ivory Coast
+CI	Ivory Coast	Republic of Cote d'Ivoire
+CI	Ivory Coast	Côte-d'Ivoire
+CI	Ivory Coast	Côte D'Ivoire
+CI	Ivory Coast	Cote D'Ivoire
+CI	Ivory Coast	Cote d'lvoire
+CI	Ivory Coast	Ivory coast
+CI	Ivory Coast	Cote D' Ivoire
+CI	Ivory Coast	Cote d' Ivoire
+CI	Ivory Coast	Côte d’Ivoire
+CM	Cameroon	Cameroon
+CM	Cameroon	Republic of Cameroon
+CM	Cameroon	Cameroonese
+CM	Cameroon	Republique du Cameroun
+CM	Cameroon	Country Cameroon
+CM	Cameroon	Camerun
+CM	Cameroon	Federal Republic of Cameroon
+CM	Cameroon	Camaroon
+CD	Democratic Republic of the Congo	Democratic Republic of the Congo
+CD	Democratic Republic of the Congo	Democratic Republic of Congo
+CD	Democratic Republic of the Congo	Congo-Kinshasa
+CD	Democratic Republic of the Congo	République Démocratique du Congo
+CD	Democratic Republic of the Congo	Republique Democratique du Congo
+CD	Democratic Republic of the Congo	Congo, Democratic Republic of the
+CD	Democratic Republic of the Congo	Congo-Kinsasha
+CD	Democratic Republic of the Congo	Congo Democratic Republic
+CG	Republic of the Congo	Republic of the Congo
+CG	Republic of the Congo	Congo-Brazzaville
+CG	Republic of the Congo	Republic of Congo
+CG	Republic of the Congo	Congo, Republic of the
+CG	Republic of the Congo	Congo Republic
+CG	Republic of the Congo	Republic Of TheCongo
+CG	Republic of the Congo	Congo, republic of the
+CG	Republic of the Congo	Ubanghi-Chari
+CK	Cook Islands	Cook Islands
+CK	Cook Islands	Country COK
+CK	Cook Islands	Cook islands
+CK	Cook Islands	The Cook Islands
+CO	Colombia	Colombia
+CO	Colombia	Republic of Colombia
+CO	Colombia	Republica de Colombia
+CO	Colombia	The Republic of Colombia
+CO	Colombia	Republic of Columbia
+CO	Colombia	El Agrado
+CO	Colombia	República de Colombia
+CO	Colombia	Colombiá
+CO	Colombia	Agrado
+KM	Comoros	Comoros
+KM	Comoros	Union of Comoros
+KM	Comoros	Comores
+KM	Comoros	The Comoros
+KM	Comoros	Comoro Isles
+KM	Comoros	Union of the Comoros
+KM	Comoros	Comoros Republic
+KM	Comoros	Islamic Federal Republic of Comoros
+KM	Comoros	جزر القمر
+KM	Comoros	Juzur al-Qumur
+CV	Cape Verde	Cape Verde
+CV	Cape Verde	Republic of Cape Verde
+CV	Cape Verde	Cape Verde Islands
+CV	Cape Verde	Cape Verde Archipelago
+CV	Cape Verde	Cape de Verd Islands
+CV	Cape Verde	Cap Verde
+CV	Cape Verde	Cape Verde islands
+CV	Cape Verde	Capo Verde
+CV	Cape Verde	Cape verde
+CR	Costa Rica	Costa Rica
+CR	Costa Rica	Costa rica
+CR	Costa Rica	Costa Rican
+CR	Costa Rica	The Republic of Costa Rica
+CR	Costa Rica	Republic of Costa Rica
+CR	Costa Rica	Countries: Costa Rica
+CR	Costa Rica	Costa-Rica
+CR	Costa Rica	Cosat Rica
+CR	Costa Rica	Coasta rica
+CU	Cuba	Cuba
+CU	Cuba	Republic of Cuba
+CU	Cuba	The Republic of Cuba
+CU	Cuba	República de Cuba
+CU	Cuba	Republica de Cuba
+CU	Cuba	CUBA
+CU	Cuba	Communist Cuba
+CW	Curaçao	Curaçao
+CW	Curaçao	Curaçoa
+CW	Curaçao	Korsou
+CW	Curaçao	Curocao
+CW	Curaçao	Kòrsou
+CW	Curaçao	Curacau
+CW	Curaçao	Curazao
+CW	Curaçao	Curacao
+CX	Christmas Island	Christmas Island
+KY	Cayman Islands	Cayman Islands
+KY	Cayman Islands	Caymans
+KY	Cayman Islands	Cayman islands
+KY	Cayman Islands	Caiman Islands
+KY	Cayman Islands	Cayman Island
+KY	Cayman Islands	Caymen islands
+KY	Cayman Islands	The Cayman Islands
+CY	Cyprus	Cyprus
+CY	Cyprus	Kypros
+CY	Cyprus	Country CYP
+CY	Cyprus	Republic of Cyprus
+CY	Cyprus	Kibris
+CY	Cyprus	Kıbrıs
+CY	Cyprus	Ciprus
+CY	Cyprus	Cyrpus
+CZ	Czech Republic	Czech Republic
+CZ	Czech Republic	Czech republic
+CZ	Czech Republic	Czeck Republic
+CZ	Czech Republic	Czec Republic
+CZ	Czech Republic	The Czech Republic
+CZ	Czech Republic	Czech Rep.
+CZ	Czech Republic	Czech Republik
+CZ	Czech Republic	Cesko
+CZ	Czech Republic	Bohemia-Moravia
+CZ	Czech Republic	Česká republika
+DE	Germany	Germany
+DE	Germany	Bundesrepublik Deutschland
+DE	Germany	Federal Republic of Germany
+DE	Germany	GerMany
+DE	Germany	GermanY
+DE	Germany	FR Germany
+DE	Germany	BR Deutschland
+DE	Germany	Deutschland
+DE	Germany	Foederal Republic of Germany
+DE	Germany	Geramny
+DJ	Djibouti	Djibouti
+DJ	Djibouti	Republic of Djibouti
+DJ	Djibouti	Djibuti
+DJ	Djibouti	Jibuti
+DJ	Djibouti	Republic Djibouti
+DJ	Djibouti	Dijibouti
+DJ	Djibouti	Djabuti
+DJ	Djibouti	Jabooty
+DJ	Djibouti	Djbouti
+DJ	Djibouti	جمهورية جيبوتي
+DM	Dominica	Dominica
+DM	Dominica	The Nature Island
+DM	Dominica	Commonwealth of Dominica
+DM	Dominica	Dominca
+DM	Dominica	The Commonwealth of Dominica
+DM	Dominica	Dominica island
+DM	Dominica	Crown Colony of Dominica
+DK	Danish Realm	Danish Realm
+DK	Danish Realm	KingdomOfDenmark
+DK	Danish Realm	Kingdom of Denmark
+DK	Danish Realm	Danish Kingdom
+DK	Danish Realm	Danish kingdom
+DK	Danish Realm	Kongeriget Danmark
+DK	Danish Realm	Rigsfaellesskabet
+DK	Danish Realm	Realm of Denmark
+DK	Danish Realm	Ríkisfelagsskapur
+DK	Danish Realm	Rigsfællesskabet
+DO	Dominican Republic	Dominican Republic
+DO	Dominican Republic	República Dominicana
+DO	Dominican Republic	Dominicanrepublic
+DO	Dominican Republic	Dominic Republican
+DO	Dominican Republic	Dominic Republic
+DO	Dominican Republic	Dominican Republican
+DO	Dominican Republic	Dominicana
+DO	Dominican Republic	Dominican republic
+DO	Dominican Republic	Cabo Falso, Dominican Republic
+DO	Dominican Republic	The Dominican Republic
+DZ	Algeria	Algeria
+DZ	Algeria	People's Democratic Republic of Algeria
+DZ	Algeria	الجمهورية الجزائرية الديمقراطية الشعبية
+DZ	Algeria	Popular Democratic Republic of Algeria
+DZ	Algeria	People’s Democratic Republic of Algeria
+DZ	Algeria	Dzayer
+DZ	Algeria	Al-Jumhūrīyah al-Jazā’irīyah
+EC	Ecuador	Ecuador
+EC	Ecuador	Republic of Ecuador
+EC	Ecuador	Equadorians
+EC	Ecuador	Equador
+EC	Ecuador	República del Ecuador
+EC	Ecuador	Republica del Ecuador
+EC	Ecuador	Ecuadorean
+EC	Ecuador	Ecuadoreans
+EG	Egypt	Egypt
+EG	Egypt	Egypte
+EG	Egypt	Egipt
+EG	Egypt	Kemmet
+EG	Egypt	مصر
+EG	Egypt	جمهوريّة مصرالعربيّة
+EG	Egypt	EGY
+EG	Egypt	Eygpt
+EG	Egypt	Republic of Egypt
+EG	Egypt	Arab Republic of Egypt
+ER	Eritrea	Eritrea
+ER	Eritrea	State of Eritrea
+ER	Eritrea	Eruthraia
+ER	Eritrea	Erythrea
+ER	Eritrea	Eriteria
+ER	Eritrea	Eritria
+ER	Eritrea	Ertra
+ER	Eritrea	Erythrée
+ER	Eritrea	Eritirea
+ER	Eritrea	Iritriya
+EH	Western Sahara	Western Sahara
+EH	Western Sahara	West Sahara
+EH	Western Sahara	Sahara Occidental
+EH	Western Sahara	Western sahara
+EH	Western Sahara	الصحراء الغربية
+EH	Western Sahara	As-Ṣaḥrā' al-Gharbīyah
+ES	Spain	Spain
+ES	Spain	Kingdom of Spain
+ES	Spain	Espanya
+ES	Spain	Espana
+ES	Spain	Reino de España
+ES	Spain	Espainiako Erresuma
+ES	Spain	Regne d'Espanha
+ES	Spain	Regne d'Espanya
+ES	Spain	Kingdom of the Spains
+ES	Spain	Reino de Espana
+EE	Estonia	Estonia
+EE	Estonia	Eesti
+EE	Estonia	Republic of Estonia
+EE	Estonia	Esthonia
+EE	Estonia	Eestimaa
+EE	Estonia	Igaunija
+EE	Estonia	Estija
+EE	Estonia	Estonija
+EE	Estonia	Estonie
+ET	Ethiopia	Ethiopia
+ET	Ethiopia	Federal Democratic Republic of Ethiopia
+ET	Ethiopia	Ityop'ia
+ET	Ethiopia	Habeshistan
+ET	Ethiopia	Etiopia
+ET	Ethiopia	Ethiopai
+ET	Ethiopia	Ethiopioa
+ET	Ethiopia	Æthiopia
+ET	Ethiopia	ኢትዮጵያ
+ET	Ethiopia	Ethiopean
+FI	Finland	Finland
+FI	Finland	FinlanD
+FI	Finland	Republic of Finland
+FI	Finland	Finnland
+FI	Finland	Suomen tasavalta
+FI	Finland	Republiken Finland
+FI	Finland	Finlande
+FI	Finland	Finnishness
+FI	Finland	Suomen Tasavalta
+FJ	Fiji	Fiji
+FJ	Fiji	Fiji Islands
+FJ	Fiji	Republic of the Fiji Islands
+FJ	Fiji	Republic of Fiji
+FJ	Fiji	Fidji Islands
+FJ	Fiji	Fijian Islands
+FJ	Fiji	Fijis
+FJ	Fiji	Sovereign Democratic Republic of Fiji
+FK	Falkland Islands	Falkland Islands
+FK	Falkland Islands	Islas Malvinas
+FK	Falkland Islands	Malvinas Islands
+FK	Falkland Islands	Falkland Isles
+FK	Falkland Islands	Faulkland Islands
+FK	Falkland Islands	Falklands
+FR	France	France
+FR	France	FrancE
+FR	France	French Republic
+FR	France	FRance
+FR	France	Frankreich
+FR	France	Belle France
+FR	France	Fracne
+FR	France	République française
+FR	France	Republic of france
+FR	France	Republic of France
+FO	Faroe Islands	Faroe Islands
+FO	Faroe Islands	Faeroe Islands
+FO	Faroe Islands	Faeroer
+FO	Faroe Islands	Faroes
+FO	Faroe Islands	The Faroe Islands
+FO	Faroe Islands	Faroe Isles
+FO	Faroe Islands	Faeroe Isles
+FO	Faroe Islands	Føroyar
+FO	Faroe Islands	Færøerne
+FM	Federated States of Micronesia	Federated States of Micronesia
+FM	Federated States of Micronesia	Federated Micronesia
+FM	Federated States of Micronesia	Micronesia, Fed. Sts.
+FM	Federated States of Micronesia	Micronesia, Federated States of
+FM	Federated States of Micronesia	Federated States of Micronesia territory, United States
+GA	Gabon	Gabon
+GA	Gabon	Gabonese Republic
+GA	Gabon	Gabun
+GA	Gabon	Magnon, Gabon
+GA	Gabon	The Gabonese Republic
+GA	Gabon	République Gabonaise
+GA	Gabon	Republique Gabonaise
+GA	Gabon	Republic of Gabon
+GB	United Kingdom	United Kingdom
+GB	United Kingdom	United Kindom
+GB	United Kingdom	U.K.
+GB	United Kingdom	UKia
+GB	United Kingdom	U.K
+GB	United Kingdom	United Kingom
+GB	United Kingdom	Uk
+GB	United Kingdom	Great Britain and Northern Ireland
+GB	United Kingdom	Kingdom of Britain
+GB	United Kingdom	The UK
+GE	Georgia	Georgia
+GE	Georgia	Georgia, State
+GE	Georgia	Geordia
+GE	Georgia	Goergia
+GE	Georgia	Georgea
+GG	Guernsey	Guernsey
+GH	Ghana	Ghana
+GH	Ghana	Republic of Ghana
+GH	Ghana	Ghanan
+GH	Ghana	Republic Ghana
+GH	Ghana	Ghanaian
+GH	Ghana	Ghanian
+GH	Ghana	The Democradic Republic of Ghana
+GH	Ghana	State of Ghana
+GH	Ghana	Republic Of Ghana
+GI	Gibraltar	Gibraltar
+GI	Gibraltar	Gibralter
+GI	Gibraltar	Gibilterra
+GI	Gibraltar	Gibraltar east
+GN	Guinea	Guinea
+GN	Guinea	Republic of Guinea
+GN	Guinea	Guinee
+GN	Guinea	Guinée
+GN	Guinea	Guinean
+GN	Guinea	Guinea Conakry
+GN	Guinea	Guinea-Conakry
+GN	Guinea	People's Revolutionary Republic of Guinea
+GN	Guinea	Guinea-Conkary
+GN	Guinea	Old Guinea
+GP	Guadeloupe	Guadeloupe
+GP	Guadeloupe	Guadaloupe
+GM	The Gambia	The Gambia
+GM	The Gambia	Republic of The Gambia
+GM	The Gambia	The Republic of The Gambia
+GM	The Gambia	Country GMB
+GM	The Gambia	The republic of gambia
+GM	The Gambia	Republic of Gambia
+GM	The Gambia	Republic of the Gambia
+GM	The Gambia	The republic of the gambia
+GM	The Gambia	Gambia, The
+GW	Guinea-Bissau	Guinea-Bissau
+GW	Guinea-Bissau	Republic of Guinea Bissau
+GW	Guinea-Bissau	Guinea Bissau
+GW	Guinea-Bissau	Guiné-Bissau
+GW	Guinea-Bissau	Giunea-bissau
+GW	Guinea-Bissau	Guinea-bissau
+GW	Guinea-Bissau	Guine–Bissau
+GW	Guinea-Bissau	Republic of Guinea-Bissau
+GW	Guinea-Bissau	Bissau-Guinea
+GW	Guinea-Bissau	Guinée-Bissau
+GQ	Equatorial Guinea	Equatorial Guinea
+GQ	Equatorial Guinea	Republic of Equatorial Guinea
+GQ	Equatorial Guinea	Guinea Ecuatorial
+GQ	Equatorial Guinea	GEQ
+GQ	Equatorial Guinea	GNQ
+GQ	Equatorial Guinea	EQG
+GQ	Equatorial Guinea	Equatoguinean
+GQ	Equatorial Guinea	Equatoguineans
+GQ	Equatorial Guinea	Equatorial guiniea
+GQ	Equatorial Guinea	Equatorial guinea
+GR	Greece	Greece
+GR	Greece	Hellenic Republic
+GR	Greece	Ελλάδα
+GR	Greece	Ellada
+GR	Greece	Ελλάς
+GR	Greece	Elás
+GR	Greece	Eládha
+GR	Greece	Hellada
+GD	Grenada	Grenada
+GD	Grenada	Grenada and Carriacou
+GD	Grenada	Grenada and the Grenadines
+GD	Grenada	Grenada, Carriacou and Petite Martinique
+GD	Grenada	Grenada, Carriacou and Petit Martinique
+GD	Grenada	Grenada, British West Indies
+GD	Grenada	Granadean
+GL	Greenland	Greenland
+GL	Greenland	Kalaallit Nunaat
+GL	Greenland	Kallaallit Nunaat
+GL	Greenland	Kangat Bay
+GL	Greenland	Island of Greenland
+GL	Greenland	Lupanglunti
+GL	Greenland	Lupanlunti
+GL	Greenland	Grinland
+GT	Guatemala	Guatemala
+GT	Guatemala	Republic Guatemala
+GT	Guatemala	Guatelmala
+GT	Guatemala	Guatamala
+GT	Guatemala	Republic of Guatemala
+GT	Guatemala	República de Guatemala
+GT	Guatemala	Gutzemala
+GT	Guatemala	Gvatemala
+GF	French Guiana	French Guiana
+GF	French Guiana	French Guyane
+GF	French Guiana	Guyane
+GF	French Guiana	Guyane française
+GF	French Guiana	Guyane Département, French Guiana
+GF	French Guiana	Guyane Département
+GF	French Guiana	French guiana
+GF	French Guiana	French guyana
+GF	French Guiana	Guyane Française
+GF	French Guiana	Région Guyane
+GU	Guam	Guam
+GU	Guam	Guahan
+GU	Guam	Guam territory, United States
+GU	Guam	Territory of Guam
+GU	Guam	Guam County, Guam
+GU	Guam	Guåhan
+GU	Guam	Guåhån
+GU	Guam	U.S. Territory of Guam
+GU	Guam	US-GU
+GY	Guyana	Guyana
+GY	Guyana	Guyanna
+GY	Guyana	Co-operative Republic of Guyana
+GY	Guyana	Gyana
+GY	Guyana	Republic of Guyana
+GY	Guyana	Cooperative Republic of Guyana
+HK	Hong Kong	Hong Kong
+HK	Hong Kong	Hongkong
+HK	Hong Kong	Hong Kong, city
+HK	Hong Kong	Hong Kong, China
+HK	Hong Kong	Hong-Kong
+HK	Hong Kong	HKSAR
+HK	Hong Kong	Hong Kong SAR, China
+HK	Hong Kong	Xianggang
+HK	Hong Kong	Heung-Gong
+HM	Heard Island and McDonald Islands	Heard Island and McDonald Islands
+HN	Honduras	Honduras
+HN	Honduras	Republic of Honduras
+HN	Honduras	Hondoras
+HN	Honduras	Spanish Honduras
+HN	Honduras	República de Honduras
+HN	Honduras	Honduran Republic
+HR	Croatia	Croatia
+HR	Croatia	Hrvatska
+HR	Croatia	Republic of Croatia
+HR	Croatia	Hirvatistan
+HR	Croatia	Kroatien
+HR	Croatia	Republika Hrvatska
+HR	Croatia	Croazia
+HR	Croatia	Kroatia
+HR	Croatia	Hravatska
+HT	Haiti	Haiti
+HT	Haiti	Hayti
+HT	Haiti	Haïti
+HT	Haiti	Republic of Haiti
+HT	Haiti	Republic of haiti
+HT	Haiti	Ayiti
+HU	Hungary	Hungary
+HU	Hungary	Republic of Hungary
+HU	Hungary	Magyarorszag
+HU	Hungary	Magyarország
+HU	Hungary	Hungarian Republic
+HU	Hungary	HUngary
+HU	Hungary	Ungarn
+HU	Hungary	Hungray
+HU	Hungary	Hungery
+HU	Hungary	Magyar Köztársaság
+ID	Indonesia	Indonesia
+ID	Indonesia	Republic of Indonesia
+ID	Indonesia	Indonisia
+ID	Indonesia	Indonesia, Republic of
+ID	Indonesia	Indonesian Empire
+ID	Indonesia	Indnonesia
+ID	Indonesia	Indonnesia
+ID	Indonesia	Indonésie
+ID	Indonesia	Indonesie
+ID	Indonesia	Republik Indonesia
+IM	Isle of Man	Isle of Man
+IM	Isle of Man	Isle Of Man
+IM	Isle of Man	Island of Man
+IM	Isle of Man	Man, Isle of
+IM	Isle of Man	Isle of Mann
+IM	Isle of Man	The Isle Of Man
+IM	Isle of Man	'Queens Commissioner-Barrantagh y Benrein'
+IM	Isle of Man	'Queen's Commissioner-Barrantagh y Benrein'
+IM	Isle of Man	'Queen's Commissioner-Barrantagh ny Benrein'
+IN	India	India
+IN	India	Republic of India
+IN	India	India proper
+IN	India	INDIA
+IN	India	Indian Republic
+IN	India	Republic of india
+IN	India	Republic Of India
+IN	India	Indya
+IO	British Indian Ocean Territory	British Indian Ocean Territory
+IE	Ireland	Ireland
+IE	Ireland	Island of Ireland
+IE	Ireland	Irish politics
+IE	Ireland	Irlandia
+IE	Ireland	Irlanda
+IE	Ireland	Irland
+IE	Ireland	The island of Ireland
+IR	Iran	Iran
+IR	Iran	Persia
+IR	Iran	Islamic Republic of Iran
+IR	Iran	Irán
+IR	Iran	Irân
+IR	Iran	La Perse
+IR	Iran	PERSIA
+IR	Iran	The Islamic Republic of Iran
+IQ	Iraq	Iraq
+IQ	Iraq	Irak
+IQ	Iraq	Al-'Iraq
+IQ	Iraq	Irak-Arabi
+IQ	Iraq	الجمهورية العراقية
+IQ	Iraq	Eragh
+IQ	Iraq	Eraq
+IQ	Iraq	العراق
+IQ	Iraq	Al-‘Irāq
+IQ	Iraq	عيَراق
+IS	Iceland	Iceland
+IS	Iceland	Ísland
+IS	Iceland	The Republic of Iceland
+IS	Iceland	Republic of Iceland
+IS	Iceland	Icealnd
+IS	Iceland	Lýðveldið ísland
+IS	Iceland	Ice-land
+IS	Iceland	Ice land
+IS	Iceland	Lydveldid island
+IL	Israel	Israel
+IL	Israel	State of Israel
+IL	Israel	The state of Israel
+IL	Israel	Yisraél
+IL	Israel	Yisrael
+IL	Israel	Isreal
+IL	Israel	Israil
+IL	Israel	Yisra'el
+IL	Israel	Yisroel
+IL	Israel	Yisroeil
+IT	Italy	Italy
+IT	Italy	ItalY
+IT	Italy	Italian Republic
+IT	Italy	Republic of Italy
+IT	Italy	Repubblica Italiana
+IT	Italy	Italie
+IT	Italy	Italia
+IT	Italy	Italija
+IT	Italy	Italiën
+JM	Jamaica	Jamaica
+JM	Jamaica	Jamica
+JM	Jamaica	Jamrock
+JM	Jamaica	Jamacia
+JM	Jamaica	Jamaca
+JM	Jamaica	Jamacian
+JM	Jamaica	Jameca
+JM	Jamaica	Jamiaca
+JM	Jamaica	Lambsriver, Westmoreland, Jamaica
+JM	Jamaica	Castleton Botanical Gardens, Jamaica
+JE	Jersey	Jersey
+JE	Jersey	Bailiwick of Jersey
+JE	Jersey	Old Jersey
+JE	Jersey	Jersey, Channel Islands
+JE	Jersey	Angia
+JE	Jersey	Isle of Jersey
+JE	Jersey	Jersey Film Festival
+JE	Jersey	Jersey bibliography
+JE	Jersey	Jèrri
+JO	Jordan	Jordan
+JO	Jordan	Hashemite Kingdom of Jordan
+JO	Jordan	Kingdom of the Jordan
+JO	Jordan	Hashemite Kingdom of the Jordan
+JO	Jordan	Kingdom of Jordan
+JO	Jordan	Al-'Urdun
+JO	Jordan	أردنّ
+JO	Jordan	المملكة الأردنّيّة الهاشميّة
+JO	Jordan	The Hashemite Kingdom of Jordan
+JP	Japan	Japan
+JP	Japan	JapaN
+JP	Japan	Nihon
+JP	Japan	JAPAN
+JP	Japan	Japang
+JP	Japan	JPN
+JP	Japan	State of Japan
+JP	Japan	The State of Japan
+JP	Japan	日本
+JP	Japan	日本国
+KZ	Kazakhstan	Kazakhstan
+KZ	Kazakhstan	Kazakstan
+KZ	Kazakhstan	Kazakhistan
+KZ	Kazakhstan	Kazhakstan
+KZ	Kazakhstan	Qazaqstan
+KZ	Kazakhstan	Republic of Kazakhstan
+KZ	Kazakhstan	Kazachstan
+KZ	Kazakhstan	Kazahstan
+KZ	Kazakhstan	Khazakstan
+KZ	Kazakhstan	Khazakastan
+KE	Kenya	Kenya
+KE	Kenya	Republic of Kenya
+KE	Kenya	Kenyan
+KE	Kenya	Kenya-Africa
+KE	Kenya	Jamhuri ya Kenya
+KG	Kyrgyzstan	Kyrgyzstan
+KG	Kyrgyzstan	Kyrgystan
+KG	Kyrgyzstan	Kirgiziya
+KG	Kyrgyzstan	Kirghizistan
+KG	Kyrgyzstan	Kirghizia
+KG	Kyrgyzstan	Kyrgyz Republic
+KG	Kyrgyzstan	Kirghizstan
+KG	Kyrgyzstan	Kirghiz Republic
+KG	Kyrgyzstan	Kyrgzystan
+KG	Kyrgyzstan	Kirgizstan
+KH	Cambodia	Cambodia
+KH	Cambodia	Kampuchea
+KH	Cambodia	Kingdom of Cambodia
+KH	Cambodia	Campuchea
+KH	Cambodia	Kâmpuchea
+KH	Cambodia	Cambodge
+KH	Cambodia	Cambodja
+KH	Cambodia	Preăh Réachéanachâkr Kâmpŭchea
+KH	Cambodia	Srok khmer
+KH	Cambodia	Preahreacheanachakr Kampuchea
+KI	Kiribati	Kiribati
+KI	Kiribati	Republic of Kiribati
+KI	Kiribati	Kiribahs
+KI	Kiribati	Kiribas
+KI	Kiribati	'kiribas
+KI	Kiribati	Ribaberikin Kiribati
+KI	Kiribati	Kearabass
+KN	Saint Kitts and Nevis	Saint Kitts and Nevis
+KN	Saint Kitts and Nevis	St. Kitts and Nevis
+KN	Saint Kitts and Nevis	St. Christopher and Nevis
+KN	Saint Kitts and Nevis	St Kitts and Nevis
+KN	Saint Kitts and Nevis	Saint Kitts & Nevis
+KN	Saint Kitts and Nevis	Saint Kitts and
+KN	Saint Kitts and Nevis	Federation of Saint Kitts and Nevis
+KN	Saint Kitts and Nevis	St. Kitts & Nevis
+KN	Saint Kitts and Nevis	St Kitts-Nevis
+KR	South Korea	South Korea
+KR	South Korea	Korea, South
+KR	South Korea	S. Korea
+KR	South Korea	Korea, Republic of
+KR	South Korea	South korea
+KR	South Korea	Republic of KOREA
+KR	South Korea	South-Korea
+KR	South Korea	Republic of korea
+KW	Kuwait	Kuwait
+KW	Kuwait	Kuwayt
+KW	Kuwait	Kuait
+KW	Kuwait	Kuwet
+KW	Kuwait	دولة الكويت
+KW	Kuwait	KUW
+KW	Kuwait	Koweit
+KW	Kuwait	State of Kuwait
+KW	Kuwait	الكويت
+KW	Kuwait	Kowait
+LA	Laos	Laos
+LA	Laos	Lao PDR
+LA	Laos	LPDR
+LA	Laos	Lao People’s Democratic Republic
+LA	Laos	Lao P.D.R.
+LA	Laos	Lao People's Democratic Republic
+LA	Laos	ສາທາລະນະລັດ ປະຊາທິປະໄຕ ປະຊາຊົນລາວ
+LA	Laos	Sathalanalat Paxathipatai Paxaxon Lao
+LB	Lebanon	Lebanon
+LB	Lebanon	Lubnaniyah
+LB	Lebanon	Lubnan
+LB	Lebanon	The Lebanon
+LB	Lebanon	Republic of Lebanon
+LB	Lebanon	Lubnān
+LB	Lebanon	Lebannon
+LB	Lebanon	Libanon
+LB	Lebanon	Lebanese Republic
+LB	Lebanon	Lebnen
+LR	Liberia	Liberia
+LR	Liberia	Republic of Liberia
+LR	Liberia	Liberian Republic
+LR	Liberia	Republic of liberia
+LR	Liberia	Libéria
+LR	Liberia	LIBERIA, West Africa
+LR	Liberia	Liberia, West Africa
+LY	Libya	Libya
+LY	Libya	Libiyah
+LY	Libya	ليبيا
+LY	Libya	LBY
+LY	Libya	Libiya
+LY	Libya	Lībiyā
+LY	Libya	Free Libya
+LY	Libya	Republic of Libya
+LY	Libya	Libyan Republic
+LC	Saint Lucia	Saint Lucia
+LC	Saint Lucia	St. Lucia
+LC	Saint Lucia	St Lucia
+LC	Saint Lucia	St.lucia
+LC	Saint Lucia	Bannzil Kwéyòl
+LC	Saint Lucia	Saint. Lucia
+LC	Saint Lucia	Bannzil Kweyol
+LC	Saint Lucia	St.Lucia
+LC	Saint Lucia	San Lucia
+LI	Liechtenstein	Liechtenstein
+LI	Liechtenstein	Leichtenstein
+LK	Sri Lanka	Sri Lanka
+LK	Sri Lanka	Ceylon
+LK	Sri Lanka	Sri lanka
+LK	Sri Lanka	Helaya
+LK	Sri Lanka	Hela Diva
+LK	Sri Lanka	Sir Lanka
+LK	Sri Lanka	Srí Lanka
+LK	Sri Lanka	Srilanka
+LK	Sri Lanka	Democratic Socialist Republic of Sri Lanka
+LK	Sri Lanka	Free Sovereign and Independent Republic of Sri Lanka
+LS	Lesotho	Lesotho
+LS	Lesotho	Kingdom of Lesotho
+LS	Lesotho	Kingdom of lesotho
+LS	Lesotho	Lethoto
+LS	Lesotho	Lesoto
+LS	Lesotho	Lestho
+LS	Lesotho	Leshoto
+LS	Lesotho	The Kingdom of Lesotho
+LT	Lithuania	Lithuania
+LT	Lithuania	Lietuva
+LT	Lithuania	Republic of Lithuania
+LT	Lithuania	Littaw
+LT	Lithuania	Lituania
+LT	Lithuania	Litauen
+LT	Lithuania	Lietova
+LT	Lithuania	Second Republic of Lithuania
+LT	Lithuania	State of Lithuania
+LT	Lithuania	Lietuvos Respublika
+LU	Luxembourg	Luxembourg
+LU	Luxembourg	LuxemburG
+LU	Luxembourg	Luxemburg
+LU	Luxembourg	Großherzogtum Luxemburg
+LU	Luxembourg	Lëtzebuerg
+LU	Luxembourg	Letzebuerg
+LU	Luxembourg	Grand Duchy of Luxembourg
+LU	Luxembourg	Grand Duchy of Luxemburg
+LU	Luxembourg	Luxemberg
+LU	Luxembourg	Country Luxembourg
+LV	Latvia	Latvia
+LV	Latvia	LatviA
+LV	Latvia	Lettonia
+LV	Latvia	Lettland
+LV	Latvia	Latvijas Republika
+LV	Latvia	Republic of Latvia
+LV	Latvia	Litavia
+LV	Latvia	Lettonie
+LV	Latvia	Letland
+LV	Latvia	Letonia
+MO	Macau	Macau
+MO	Macau	Macao
+MO	Macau	Macau Special Administrative Region
+MO	Macau	Aumen
+MO	Macau	Ao-men
+MO	Macau	Macau SAR
+MO	Macau	Macau SAR, China
+MO	Macau	Àomén
+MO	Macau	Haojing'ao
+MO	Macau	Xiangshan'ao
+MF	Collectivity of Saint Martin	Saint-Martin, Guadeloupe
+MF	Collectivity of Saint Martin	Collectivité de Saint-Martin
+MA	Morocco	Morocco
+MA	Morocco	Morrocco
+MA	Morocco	Morroco
+MA	Morocco	Kingdom of Morocco
+MA	Morocco	Maroc
+MA	Morocco	Kingdom of Fez
+MA	Morocco	Marokko
+MA	Morocco	Kingdom of Fes
+MA	Morocco	Moroco
+MA	Morocco	Sultanate of Morocco
+MC	Monaco	Monaco
+MC	Monaco	Munegu
+MC	Monaco	Monocco
+MC	Monaco	Monacco
+MD	Moldova	Moldova
+MD	Moldova	Moldovia
+MD	Moldova	Country MDA
+MD	Moldova	Moldowa
+MD	Moldova	Moldova, Republic of
+MD	Moldova	Republic of Moldavia
+MG	Madagascar	Madagascar
+MG	Madagascar	Republic of Madagascar
+MG	Madagascar	Madagaskar
+MG	Madagascar	Madegascar
+MG	Madagascar	Madegasgar
+MG	Madagascar	Madagasgar
+MG	Madagascar	Madgascar
+MG	Madagascar	Island of the moon
+MG	Madagascar	Island of the Moon
+MV	Maldives	Maldives
+MV	Maldives	Maldive
+MV	Maldives	The Maldives
+MV	Maldives	Maldive Islands
+MV	Maldives	Republic of Maldives
+MV	Maldives	Republic of the Maldives
+MV	Maldives	The Republic of Maldives
+MV	Maldives	Maledives
+MV	Maldives	Maldives island
+MX	Mexico	Mexico
+MX	Mexico	United States of Mexico
+MX	Mexico	México
+MX	Mexico	United Mexican States
+MX	Mexico	Estados Unidos Mexicanos
+MX	Mexico	Méjico
+MX	Mexico	Mejico
+MX	Mexico	Republic of Mexico
+MX	Mexico	Mexicó
+MX	Mexico	United states of mexico
+MH	Marshall Islands	Marshall Islands
+MH	Marshall Islands	Republic of the Marshall Islands
+MH	Marshall Islands	Marshal Islands
+MH	Marshall Islands	Marshall Islands territory, United States
+MH	Marshall Islands	The Marshall Islands
+MH	Marshall Islands	Marshall islands
+MH	Marshall Islands	Aolepān Aorōkin M̧ajeļ
+MH	Marshall Islands	Aolepan Aorokin Majel
+MH	Marshall Islands	Marshall island
+MH	Marshall Islands	Marshall Is.
+MK	North Macedonia	North Macedonia
+MK	North Macedonia	FYROM
+MK	North Macedonia	Former Yugoslav Republic of Macedonia
+MK	North Macedonia	The Former Yugoslav Republic of Macedonia
+MK	North Macedonia	Macedonia, The Former Yugoslav Republic of
+MK	North Macedonia	TFYRM
+MK	North Macedonia	TFYR
+MK	North Macedonia	TFYR Macedonia
+MK	North Macedonia	Republic Macedonia
+ML	Mali	Mali
+ML	Mali	Republic of Mali
+ML	Mali	The Republic of Mali
+ML	Mali	République du Mali
+ML	Mali	Malian Republic
+ML	Mali	MALI
+ML	Mali	Republique Du Mali
+MT	Malta	Malta
+MT	Malta	Republic of Malta
+MT	Malta	Maltese Islands
+MT	Malta	Malta GC
+MT	Malta	Maltese islands
+MT	Malta	Maltese archipelago
+MM	Myanmar	Myanmar
+MM	Myanmar	Mayanmar
+MM	Myanmar	Birma
+MM	Myanmar	Mianmar
+MM	Myanmar	Pyi-daung-zu Myan-ma Naing-ngan-daw
+MM	Myanmar	Union of burma
+ME	Montenegro	Montenegro
+ME	Montenegro	Republika Crna Gora
+ME	Montenegro	Република Црна Гора
+ME	Montenegro	Muntenegru
+ME	Montenegro	Montenengro
+ME	Montenegro	Monténégro
+ME	Montenegro	Montonegro
+ME	Montenegro	Mali I Zi
+ME	Montenegro	Црна Гора
+MN	Mongolia	Mongolia
+MN	Mongolia	Republic of Mongolia
+MN	Mongolia	Republic Mongolia
+MN	Mongolia	Mongol Uls
+MN	Mongolia	Mongolian Republic
+MN	Mongolia	Монгол Улс
+MN	Mongolia	Mongol Nation
+MP	Northern Mariana Islands	Northern Mariana Islands
+MP	Northern Mariana Islands	Communications on the Northern Mariana Islands
+MP	Northern Mariana Islands	Transportation on the Northern Mariana Islands
+MP	Northern Mariana Islands	Northern Marianas
+MZ	Mozambique	Mozambique
+MZ	Mozambique	Republic of Mozambique
+MZ	Mozambique	Moçambique
+MZ	Mozambique	Mosambique
+MZ	Mozambique	Mocambique
+MZ	Mozambique	Mozambic
+MZ	Mozambique	Mozambik
+MZ	Mozambique	Mozambiquan
+MR	Mauritania	Mauritania
+MR	Mauritania	Islamic Republic of Mauritania
+MR	Mauritania	Muritaniyah
+MR	Mauritania	Boumdeït
+MR	Mauritania	Mauritanians
+MR	Mauritania	Mauritanie
+MR	Mauritania	Muritania
+MR	Mauritania	Mūrītāniyā
+MS	Montserrat	Montserrat
+MS	Montserrat	Saint Anthony Parish, Montserrat
+MQ	Martinique	Martinique
+MQ	Martinique	Martinique Département
+MQ	Martinique	Martinique Département, Martinique
+MQ	Martinique	MTQ
+MQ	Martinique	Martiniquan
+MQ	Martinique	Région Martinique
+MQ	Martinique	Martinican
+MQ	Martinique	Martinique Departement
+MU	Mauritius	Mauritius
+MU	Mauritius	Republic of Mauritius
+MU	Mauritius	Mauritus
+MU	Mauritius	Ile Maurice
+MU	Mauritius	Île Maurice
+MU	Mauritius	Maurituis
+MW	Malawi	Malawi
+MW	Malawi	Republic of Malawi
+MW	Malawi	Republic Malawi
+MW	Malawi	Malawi, Africa
+MW	Malawi	Mala?i
+MW	Malawi	Republic of Malaŵi
+MW	Malawi	Malaŵi
+MW	Malawi	Malawian language
+MW	Malawi	The Warm Heart of Africa
+MY	Malaysia	Malaysia
+MY	Malaysia	Federation of Malaysia
+MY	Malaysia	M'sia
+MY	Malaysia	Malyasia
+MY	Malaysia	Malaysian Federation
+MY	Malaysia	Malayasia
+MY	Malaysia	Maylaysia
+MY	Malaysia	Malasia
+MY	Malaysia	Malaisia
+MY	Malaysia	Republic of Malaysia
+YT	Mayotte	Mayotte
+YT	Mayotte	Ile Mayotte
+YT	Mayotte	Mahoré
+NA	Namibia	Namibia
+NA	Namibia	Republic of Namibia
+NA	Namibia	Namibians
+NA	Namibia	Nambam
+NA	Namibia	Nam bam
+NA	Namibia	Nambia
+NA	Namibia	Namibian
+NA	Namibia	The Republic of Namibia
+NA	Namibia	Republiek van Namibië
+NC	New Caledonia	New Caledonia
+NC	New Caledonia	Kanaky
+NC	New Caledonia	Kanaky.
+NC	New Caledonia	New Caledonia and Dependencies
+NC	New Caledonia	Nouvelle-Calédonie
+NC	New Caledonia	Collectivité sui generis
+NE	Niger	Niger
+NE	Niger	Republic of Niger
+NE	Niger	Niger Republic
+NE	Niger	Republic Of Niger
+NE	Niger	Republique du Niger
+NE	Niger	République du Niger
+NE	Niger	The Republic of Niger
+NE	Niger	The Niger
+NE	Niger	Republic of the Niger
+NF	Norfolk Island	Norfolk Island
+NF	Norfolk Island	Communications on Norfolk Island
+NF	Norfolk Island	Transportation on Norfolk Island
+NG	Nigeria	Nigeria
+NG	Nigeria	Federal Republic of Nigeria
+NG	Nigeria	Ìjọba-Àpapọ̀ Orílẹ̀-èdè Naìjírìà
+NG	Nigeria	Ijoba-Apapo Orile-ede Naijiria
+NG	Nigeria	Naìjírìà
+NG	Nigeria	Naijiria
+NG	Nigeria	Republik Nijeriya
+NG	Nigeria	Nijeriya
+NG	Nigeria	Republic nde Naigeria
+NG	Nigeria	Naigeria
+NI	Nicaragua	Nicaragua
+NI	Nicaragua	The Republic of Nicaragua
+NI	Nicaragua	Nicaragua, Central America
+NI	Nicaragua	Republic of Nicaragua
+NI	Nicaragua	Nicarugua
+NI	Nicaragua	Nicuragua
+NI	Nicaragua	Republica De Nicaragua
+NI	Nicaragua	República de Nicaragua
+NI	Nicaragua	Nicaraguan
+NU	Niue	Niue
+NU	Niue	Niue Island
+NU	Niue	Niué
+NU	Niue	Niue Business Centre
+NU	Niue	Niuē
+NU	Niue	Niuē Fekai
+NU	Niue	Niue Fekai
+NL	Kingdom of the Netherlands	Kingdom of the Netherlands
+NL	Kingdom of the Netherlands	Koninkrijk der Nederlanden
+NL	Kingdom of the Netherlands	The Kingdom of the Netherlands
+NL	Kingdom of the Netherlands	Kingdom of The Netherlands
+NL	Kingdom of the Netherlands	Kingdom Of the Netherlands
+NL	Kingdom of the Netherlands	Kingdom Of The Netherlands
+NL	Kingdom of the Netherlands	Reino Hulandes
+NO	Norway	Norway
+NO	Norway	Noreg
+NO	Norway	Norwegian state
+NO	Norway	Kingdom of Norway
+NO	Norway	Norwegian kingdom
+NO	Norway	Kongeriket Norge
+NO	Norway	Kongeriket Noreg
+NO	Norway	Noregur
+NO	Norway	Norwegia
+NP	Nepal	Nepal
+NP	Nepal	The Kingdom of Nepal
+NP	Nepal	Nepaul
+NP	Nepal	Nēpāl Adhirājya
+NP	Nepal	State of Nepal
+NP	Nepal	Republic of nepal
+NP	Nepal	Republic of Nepal
+NP	Nepal	Nepal Adhirajya
+NR	Nauru	Nauru
+NR	Nauru	Moque Well
+NR	Nauru	Moqua Cave
+NR	Nauru	Nauru Island
+NR	Nauru	Republic of Nauru
+NR	Nauru	Naoero
+NZ	New Zealand	New Zealand
+NZ	New Zealand	NewZealand
+NZ	New Zealand	Nz
+NZ	New Zealand	Niu Tireni
+NZ	New Zealand	Nu Tirani
+NZ	New Zealand	New zealand
+NZ	New Zealand	New zeeland
+NZ	New Zealand	New zeland
+NZ	New Zealand	NZ
+OM	Oman	Oman
+OM	Oman	Sultanate of Oman
+OM	Oman	سلطنة عُمان
+OM	Oman	OMN
+OM	Oman	عُمان
+OM	Oman	ʕumān
+OM	Oman	`Umān
+OM	Oman	Umman
+PK	Pakistan	Pakistan
+PK	Pakistan	Islamic Republic of Pakistan
+PK	Pakistan	Republic of Pakistan
+PK	Pakistan	Bakistan
+PK	Pakistan	Bakstaan
+PK	Pakistan	Bakistaan
+PK	Pakistan	Pakstan
+PK	Pakistan	Packistan
+PK	Pakistan	Islamic Republic Of Pakistan
+PA	Panama	Panama
+PA	Panama	Panamá
+PA	Panama	Republic of Panama
+PA	Panama	Republic of Panamá
+PA	Panama	Panamà
+PA	Panama	República de Panamá
+PN	Pitcairn Islands	Pitcairn Islands
+PN	Pitcairn Islands	PitcairnIsland
+PN	Pitcairn Islands	Pitcairn Island
+PN	Pitcairn Islands	Communications on the Pitcairn Islands
+PN	Pitcairn Islands	Transportation on the Pitcairn Islands
+PN	Pitcairn Islands	Pitcairn
+PE	Peru	Peru
+PE	Peru	Perú
+PE	Peru	Péru
+PE	Peru	Peruvian Republic
+PE	Peru	Piruw
+PE	Peru	El Perú
+PE	Peru	Republic of Peru
+PE	Peru	El Peru
+PE	Peru	Peruano
+PE	Peru	Republic of Perú
+PH	Philippines	Philippines
+PH	Philippines	The Philippines
+PH	Philippines	Phillipine
+PH	Philippines	Phillipines
+PH	Philippines	Philippines Republic
+PH	Philippines	Philippine Islands
+PH	Philippines	Republic of the Philippines
+PH	Philippines	Philippine
+PH	Philippines	Phillippines
+PH	Philippines	The Phillipines
+PW	Palau	Palau
+PW	Palau	Palau Islands
+PW	Palau	Republic of Palau
+PW	Palau	Palaus
+PW	Palau	Pelew Islands
+PG	Papua New Guinea	Papua New Guinea
+PG	Papua New Guinea	PapuaNewGuineA
+PG	Papua New Guinea	New Guinea Papua
+PG	Papua New Guinea	Pua pua new guniea
+PG	Papua New Guinea	Papau New Guinea
+PG	Papua New Guinea	Papua-New Guinea
+PG	Papua New Guinea	Papua-New-Guinea
+PG	Papua New Guinea	Independent State of Papua New Guinea
+PG	Papua New Guinea	Papua new guinea
+PG	Papua New Guinea	Paupa New Guinea
+PL	Poland	Poland
+PL	Poland	Polskor
+PL	Poland	Polland
+PL	Poland	Republic of Poland
+PL	Poland	Rzeczpospolita Polska
+PL	Poland	Polish state
+PL	Poland	Polska
+PL	Poland	Pologne
+PL	Poland	Ploand
+PL	Poland	Polnd
+PR	Puerto Rico	Puerto Rico
+PR	Puerto Rico	Puetro Rico
+PR	Puerto Rico	Porto Rico
+PR	Puerto Rico	Peurto Rico
+PR	Puerto Rico	Estado Libre Asociado
+PR	Puerto Rico	Borikén
+PR	Puerto Rico	Puerto rico
+PR	Puerto Rico	Commonwealth of Puerto Rico
+PR	Puerto Rico	Boriken
+KP	North Korea	North Korea
+KP	North Korea	Korea, North
+KP	North Korea	N Korea
+KP	North Korea	N. Korea
+KP	North Korea	DPRK
+KP	North Korea	Democratic Peoples' Republic of Korea
+KP	North Korea	D.P.R.K.
+KP	North Korea	Democratic Peoples Republic of Korea
+KP	North Korea	North-Korea
+PT	Portugal	Portugal
+PT	Portugal	Portugual
+PT	Portugal	Portgual
+PT	Portugal	Portugalia
+PT	Portugal	Portuguese Republic
+PT	Portugal	República Portuguesa
+PT	Portugal	Portugál
+PT	Portugal	Portugall
+PT	Portugal	Portegal
+PT	Portugal	Portugaul
+PY	Paraguay	Paraguay
+PY	Paraguay	Republic Paraguay
+PY	Paraguay	Paraguayan
+PY	Paraguay	Paragauy
+PY	Paraguay	Republic of Paraguay
+PY	Paraguay	Paruaguayan
+PY	Paraguay	Paraguai
+PY	Paraguay	Tetã Paraguái
+PY	Paraguay	Teta Paraguai
+PS	State of Palestine	State of Palestine
+PS	State of Palestine	Palestinian homeland
+PS	State of Palestine	Palestinian state
+PS	State of Palestine	The State of Palestine
+PS	State of Palestine	State-of-palestine
+PS	State of Palestine	Palestinian State
+PS	State of Palestine	Palestinian states
+PS	State of Palestine	Western Palestine
+PF	French Polynesia	French Polynesia
+PF	French Polynesia	French Oceania
+PF	French Polynesia	Polynesie
+PF	French Polynesia	Polynésie Française Territoire
+PF	French Polynesia	Polynésie Française Territoire, French Polynesia
+PF	French Polynesia	Polynesie Francaise Territoire, French Polynesia
+PF	French Polynesia	PYF
+QA	Qatar	Qatar
+QA	Qatar	Quatar
+QA	Qatar	دولة قطر
+QA	Qatar	قطر
+QA	Qatar	Dawlat Qatar
+QA	Qatar	State of Qatar
+QA	Qatar	Qatari
+QA	Qatar	Qtaar
+QA	Qatar	Qaṭar
+RE	Réunion	Réunion
+RE	Réunion	Reunion Island
+RE	Réunion	Isle of Bourbon
+RE	Réunion	La Réunion
+RE	Réunion	Réunion Island
+RE	Réunion	Reunion island
+RE	Réunion	Réunion, Reunion
+RO	Romania	Romania
+RO	Romania	Rumania
+RO	Romania	Roumania
+RO	Romania	Country ROM
+RO	Romania	Rumunia
+RO	Romania	România
+RO	Romania	Romanian State
+RO	Romania	Roumanie
+RO	Romania	Romainia
+RO	Romania	Rumänien
+RU	Russia	Russia
+RU	Russia	Russian Federation
+RU	Russia	Russian federation
+RU	Russia	Rossiyskaya Federatsiya
+RU	Russia	Venäjä
+RU	Russia	Novaya russia
+RU	Russia	Russland
+RU	Russia	Россия
+RU	Russia	Росси́йская Федера́ция
+RU	Russia	Rossijskaja Federatsija
+RW	Rwanda	Rwanda
+RW	Rwanda	Republic of Rwanda
+RW	Rwanda	Rawanda
+RW	Rwanda	Rwandese Republic
+RW	Rwanda	Ruanda
+RW	Rwanda	Ruando
+RW	Rwanda	Rwnanda
+RW	Rwanda	Land of a Thousand Hills
+RW	Rwanda	Pays des mille collines
+RW	Rwanda	Pays des milles collines
+SA	Saudi Arabia	Saudi Arabia
+SA	Saudi Arabia	Saudi-Arabia
+SA	Saudi Arabia	Al-Arabiyah as Sa'udiyah
+SA	Saudi Arabia	Sauri Arabia
+SA	Saudi Arabia	Kingdom of Saudi Arabia
+SA	Saudi Arabia	المملكة العربية السعودية
+SA	Saudi Arabia	Saudi arabia
+SA	Saudi Arabia	Saudia Arabia
+SA	Saudi Arabia	السعودية
+SA	Saudi Arabia	Saoudi Arabia
+SD	Sudan	Sudan
+SD	Sudan	Republic of Sudan
+SD	Sudan	Sudanese Republic
+SD	Sudan	Republic of the Sudan
+SD	Sudan	The Sudan
+SD	Sudan	As-Sudan
+SD	Sudan	جمهورية السودان
+SN	Senegal	Senegal
+SN	Senegal	Republic of Senegal
+SN	Senegal	Sénégal
+SN	Senegal	Republic of Sénégal
+SN	Senegal	Senegalese
+SN	Senegal	République du Sénégal
+SN	Senegal	Sengal
+SG	Singapore	Singapore
+SG	Singapore	Cingkappur
+SG	Singapore	Xinjiapo
+SG	Singapore	Singapura
+SG	Singapore	Cingkappur Kudiyaracu
+SG	Singapore	Republik Singapura
+SG	Singapore	Xinjiapo Gònghégúo
+SG	Singapore	Xinjiapo Gongheguo
+SG	Singapore	Singpore
+SG	Singapore	S'pore
+GS	South Georgia and the South Sandwich Islands	South Georgia and the South Sandwich Islands
+GS	South Georgia and the South Sandwich Islands	South Sandwich Islands
+GS	South Georgia and the South Sandwich Islands	South Georgia and South Sandwich Islands
+SH	Saint Helena, Ascension and Tristan da Cunha	Saint Helena, Ascension and Tristan da Cunha
+SH	Saint Helena, Ascension and Tristan da Cunha	St Helena and Dependencies
+SH	Saint Helena, Ascension and Tristan da Cunha	Saint Helena and Dependencies
+SH	Saint Helena, Ascension and Tristan da Cunha	St Helena, Ascension and Tristan da Cunha
+SJ	Svalbard and Jan Mayen	Svalbard and Jan Mayen
+SJ	Svalbard and Jan Mayen	Svalbard and Jan Mayen Islands
+SJ	Svalbard and Jan Mayen	Svalbard and Jan Meyen
+SJ	Svalbard and Jan Mayen	Svalbard And Jan Mayen
+SJ	Svalbard and Jan Mayen	Svalbard & Jan Mayen
+SB	Solomon Islands	Solomon Islands
+SB	Solomon Islands	Solomon islands
+SB	Solomon Islands	The Solomon Islands
+SB	Solomon Islands	Solomon Island
+SB	Solomon Islands	Solomon Islands, Southern
+SB	Solomon Islands	Solomon Is
+SB	Solomon Islands	Solomon Is.
+SL	Sierra Leone	Sierra Leone
+SL	Sierra Leone	Republic of Sierra Leone
+SL	Sierra Leone	Sierra Leome
+SL	Sierra Leone	Sierra leon
+SL	Sierra Leone	Sierra Leonean
+SL	Sierra Leone	Sierra leone
+SL	Sierra Leone	Serra leoa
+SL	Sierra Leone	Sierra lione
+SL	Sierra Leone	Sierra Leon
+SL	Sierra Leone	Sierra Leone Public Archives
+SV	El Salvador	El Salvador
+SV	El Salvador	República de El Salvador
+SV	El Salvador	Salvador, El
+SV	El Salvador	El Salvador: Gangs
+SV	El Salvador	Republic of El Salvador
+SV	El Salvador	El Salbador
+SV	El Salvador	Elsalbador
+SV	El Salvador	El salvador
+SV	El Salvador	EL Salvador
+SV	El Salvador	Salvadoreans
+SM	San Marino	San Marino
+SM	San Marino	Republic of San Marino
+SM	San Marino	Capitani reggenti
+SM	San Marino	San marino
+SM	San Marino	Most Serene Republic of San Marino
+SM	San Marino	Republic of S.Marino
+SM	San Marino	Saint-Marin
+SM	San Marino	Sanmarinese
+SM	San Marino	Land of San Marino
+SO	Somalia	Somalia
+SO	Somalia	Republic of Somalia
+SO	Somalia	Somalia, Africa
+SO	Somalia	Somaliya
+SO	Somalia	Soomaaliya
+SO	Somalia	As-Sumal
+SO	Somalia	Somolia
+SO	Somalia	Somaila
+SO	Somalia	The Independent Somali State
+SO	Somalia	Federal Republic of Somalia
+PM	Saint Pierre and Miquelon	Saint Pierre and Miquelon
+PM	Saint Pierre and Miquelon	St. Pierre and Miquelon
+PM	Saint Pierre and Miquelon	Saint Pierre and
+PM	Saint Pierre and Miquelon	St Pierre and Miquelon
+PM	Saint Pierre and Miquelon	Saint-Pierre-et-Miquelon
+PM	Saint Pierre and Miquelon	Saint-Pierre et Miquelon
+PM	Saint Pierre and Miquelon	Saint Pierre et Miquelon
+RS	Serbia	Serbia
+RS	Serbia	Srvija
+RS	Serbia	Republic of Serbia
+RS	Serbia	Serbian state
+RS	Serbia	RS of Serbia
+RS	Serbia	Србија
+RS	Serbia	Republika Srbija
+RS	Serbia	Република Србија
+RS	Serbia	Serbo
+RS	Serbia	Srbija
+SS	South Sudan	South Sudan
+SS	South Sudan	Southern Sudanese
+SS	South Sudan	S. Sudan
+SS	South Sudan	Republic of South Sudan
+SS	South Sudan	Southern sudan
+SS	South Sudan	جنوب السودان
+SS	South Sudan	Janūb as-Sūdān
+SS	South Sudan	Janub as-Sudan
+SS	South Sudan	Republic of Southern Sudan
+SS	South Sudan	Nilotic Republic
+SS	South Sudan	Southern Sudan
+ST	São Tomé and Príncipe	São Tomé and Príncipe
+ST	São Tomé and Príncipe	Republic of Sao Tome and Principe
+ST	São Tomé and Príncipe	Saint Thomas and Prince
+ST	São Tomé and Príncipe	Sao Taome and Principe
+ST	São Tomé and Príncipe	Democratic Republic of São Tomé and Príncipe
+ST	São Tomé and Príncipe	Republic of São Tomé and Príncipe
+ST	São Tomé and Príncipe	São Tomé and Principe
+ST	São Tomé and Príncipe	São Thomé and Principe
+ST	São Tomé and Príncipe	Sao Tome Principe
+ST	São Tomé and Príncipe	Sao Tomé and Príncipe
+SR	Suriname	Suriname
+SR	Suriname	Surinam
+SR	Suriname	Republic of Suriname
+SR	Suriname	NGY
+SR	Suriname	Sranang
+SK	Slovakia	Slovakia
+SK	Slovakia	Slovensko
+SK	Slovakia	Slovokia
+SK	Slovakia	Slovakland
+SK	Slovakia	Slovak Republic
+SK	Slovakia	Slovak republic
+SK	Slovakia	Szlovákia
+SK	Slovakia	Republic of Slovakia
+SK	Slovakia	Szlovakia
+SI	Slovenia	Slovenia
+SI	Slovenia	Slovenija
+SI	Slovenia	Republic of Slovenia
+SI	Slovenia	Slovénie
+SI	Slovenia	Slovenie
+SI	Slovenia	Republika Slovenija
+SI	Slovenia	Szlovénia
+SI	Slovenia	Szlovenia
+SI	Slovenia	Slowenia
+SI	Slovenia	Slovenia's independence
+SE	Sweden	Sweden
+SE	Sweden	Swedish realm
+SE	Sweden	Konungariket Sverige
+SE	Sweden	Svithiod
+SE	Sweden	Sverige
+SE	Sweden	Sveden
+SE	Sweden	Kingdom of Sweden
+SE	Sweden	Schweden
+SE	Sweden	Swedish origin
+SZ	Eswatini	Eswatini
+SZ	Eswatini	Swazi Kingdom
+SZ	Eswatini	Kingdom of Swaziland
+SZ	Eswatini	Swasiland
+SZ	Eswatini	Umbuso waseSwatini
+SZ	Eswatini	Umbuso weSwatini
+SX	Sint Maarten	Sint Maarten
+SX	Sint Maarten	Saint Maartin
+SX	Sint Maarten	Sint Maartin
+SX	Sint Maarten	Sint Marteen
+SX	Sint Maarten	St. Maarten
+SX	Sint Maarten	St.maarten
+SX	Sint Maarten	Saint Maarten
+SX	Sint Maarten	St Maarten
+SX	Sint Maarten	Sint-Maarten
+SX	Sint Maarten	Sint Maarten, Netherlands Antilles
+SC	Seychelles	Seychelles
+SC	Seychelles	Republic of Seychelles
+SC	Seychelles	The Seychelles
+SC	Seychelles	Seychelles Islands
+SC	Seychelles	Seychelle Islands
+SC	Seychelles	Seychelles islands
+SC	Seychelles	Seichelles
+SC	Seychelles	Seicheles
+SC	Seychelles	Seychellois
+SY	Syria	Syria
+SY	Syria	Syrian Arab Republic
+SY	Syria	Suriyah
+SY	Syria	الجمهوريّة العربيّة السّوريّة
+SY	Syria	Souria
+SY	Syria	Syrie
+SY	Syria	Sūriyā
+SY	Syria	الجمهورية العربية السورية
+TC	Turks and Caicos Islands	Turks and Caicos Islands
+TC	Turks and Caicos Islands	Turks and Caicos
+TC	Turks and Caicos Islands	Turks & Caicos
+TD	Chad	Chad
+TD	Chad	Republic of Chad
+TD	Chad	Tchad
+TD	Chad	تشاد
+TD	Chad	The Chad
+TD	Chad	Chade
+TD	Chad	Tshād
+TD	Chad	République du Tchad
+TD	Chad	Republique du Tchad
+TG	Togo	Togo
+TG	Togo	Togolese Republic
+TG	Togo	BQG
+TG	Togo	République Togolaise
+TG	Togo	Togolese
+TG	Togo	Republique Togolaise
+TG	Togo	Republic of Togo
+TH	Thailand	Thailand
+TH	Thailand	Kingdom of Thailand
+TH	Thailand	Sayam
+TH	Thailand	Tailand
+TH	Thailand	THAILAND
+TH	Thailand	ประเทศไทย
+TH	Thailand	เมืองไทย
+TH	Thailand	Taihland
+TH	Thailand	Thaïlande
+TH	Thailand	Thailande
+TJ	Tajikistan	Tajikistan
+TJ	Tajikistan	Tadzikhistan
+TJ	Tajikistan	Tadzhikistan
+TJ	Tajikistan	Tojikiston
+TJ	Tajikistan	Tajikstan
+TJ	Tajikistan	Tojikistan
+TJ	Tajikistan	Tadjikistan
+TJ	Tajikistan	Republic of Tajikistan
+TJ	Tajikistan	Tajikestan
+TJ	Tajikistan	Tadschikistan
+TK	Tokelau	Tokelau
+TM	Turkmenistan	Turkmenistan
+TM	Turkmenistan	Turkmenostan
+TM	Turkmenistan	Welayatlar of Turkmenistan
+TM	Turkmenistan	Province of Turkmenistan
+TM	Turkmenistan	Republic of Turkmenistan
+TM	Turkmenistan	Türkmenistan
+TM	Turkmenistan	Turkmania
+TM	Turkmenistan	Turkmanistan
+TL	East Timor	East Timor
+TL	East Timor	Democratic Republic of Timor-Leste
+TL	East Timor	Timor Lorosa'e
+TL	East Timor	Repúblika Demokrátika Timor Lorosa'e
+TL	East Timor	Republika Demokratika Timor Lorosa'e
+TL	East Timor	República Democrática de Timor-Leste
+TL	East Timor	Republica Democratica de Timor-Leste
+TL	East Timor	East-Timor
+TL	East Timor	East timor
+TO	Tonga	Tonga
+TO	Tonga	Friendly Islands
+TO	Tonga	Kingdom of Tonga
+TO	Tonga	Kingdom of tonga
+TO	Tonga	Tongan Rugby
+TO	Tonga	Puleʻanga Fakatuʻi ʻo Tonga
+TO	Tonga	Makatusi
+TO	Tonga	Pule`anga Fakatu`i `o Tonga
+TO	Tonga	The Kingdom of Tonga
+TO	Tonga	Pule'anga Fakatu'i'o, Tonga
+TT	Trinidad and Tobago	Trinidad and Tobago
+TT	Trinidad and Tobago	Trinidad, British West Indies
+TT	Trinidad and Tobago	Trinidad & Tobago
+TT	Trinidad and Tobago	Trinidad and tobago
+TT	Trinidad and Tobago	Trindiad and Tobago
+TT	Trinidad and Tobago	Republic of Trinidad and Tobago
+TT	Trinidad and Tobago	Republic of trinidad
+TT	Trinidad and Tobago	Trinidad& Tobago
+TT	Trinidad and Tobago	Trinidad y Tobago
+TN	Tunisia	Tunisia
+TN	Tunisia	Republic of Tunisia
+TN	Tunisia	Tounisiyya
+TN	Tunisia	الجمهورية التونسية
+TN	Tunisia	Tunnisia
+TN	Tunisia	Tunisian Republic
+TN	Tunisia	Tounes
+TN	Tunisia	Tunesia
+TN	Tunisia	تونس
+TN	Tunisia	Tunisie
+TR	Turkey	Turkey
+TR	Turkey	Republic of Turkey
+TR	Turkey	Republic of turkey
+TR	Turkey	Türkiye Cumhuriyeti
+TR	Turkey	Turkish republic
+TR	Turkey	Turkiye
+TR	Turkey	Turky
+TV	Tuvalu	Tuvalu
+TV	Tuvalu	Ellice Islands
+TV	Tuvalu	Ellice Island
+TV	Tuvalu	Tuvalu Islands
+TV	Tuvalu	Toovaloo
+TW	Taiwan, China	Taiwan, China
+TW	Taiwan, China	Taiwan, Province of China
+TW	Taiwan, China	Taiwan Province of China
+TW	Taiwan, China	Taiwan,China
+TW	Taiwan, China	Taiwan Province, China
+TW	Taiwan, China	中國臺灣
+TW	Taiwan, China	Taiwan China
+TW	Taiwan, China	China Taiwan
+TW	Taiwan, China	Chinese Taiwan
+TZ	Tanzania	Tanzania
+TZ	Tanzania	United Republic of Tanzania
+TZ	Tanzania	Tanzanian
+TZ	Tanzania	Tansania
+TZ	Tanzania	Republic of Tanzania
+TZ	Tanzania	United Republic of Tanganyika and Zanzibar
+TZ	Tanzania	Tanzanie
+TZ	Tanzania	Jamhuri ya Muungano wa Tanzania
+TZ	Tanzania	Tanzania, United Republic of
+TZ	Tanzania	Tanganyika and Zanzibar
+UG	Uganda	Uganda
+UG	Uganda	Republic of Uganda
+UG	Uganda	Ugandan
+UG	Uganda	Ouganda
+UG	Uganda	Ugandese
+UG	Uganda	Ugandan nationalism
+UG	Uganda	The Republic of Uganda
+UG	Uganda	Republic of uganda
+UA	Ukraine	Ukraine
+UA	Ukraine	The Ukraine
+UA	Ukraine	Ukraina
+UA	Ukraine	Ukrayina
+UA	Ukraine	UKR
+UA	Ukraine	Ucraine
+UA	Ukraine	Україна
+UA	Ukraine	Ukrania
+UA	Ukraine	Ukrajina
+UA	Ukraine	Ukrane
+UM	United States Minor Outlying Islands	United States Minor Outlying Islands
+UM	United States Minor Outlying Islands	U.S. Minor Outlying Islands
+UM	United States Minor Outlying Islands	US minor outlying islands
+UM	United States Minor Outlying Islands	US Minor Outlying Islands
+UM	United States Minor Outlying Islands	US Outlying Islands
+UM	United States Minor Outlying Islands	USMOI
+UM	United States Minor Outlying Islands	U.S. Minor Outlying Island
+UM	United States Minor Outlying Islands	United States Minor Outlying Island
+UM	United States Minor Outlying Islands	US-UM
+UM	United States Minor Outlying Islands	United States Minor Islands
+UY	Uruguay	Uruguay
+UY	Uruguay	Uraguay
+UY	Uruguay	Republic East of the Uruguay
+UY	Uruguay	Uruguai
+UY	Uruguay	Eastern Republic of Uruguay
+UY	Uruguay	Eastern Republic of the Uruguay
+UY	Uruguay	Oriental Republic of Uruguay
+US	United States	United States
+US	United States	AmericA
+US	United States	UnitedStates
+US	United States	US
+US	United States	USA
+US	United States	U.S.
+US	United States	U.S.A.
+US	United States	United States of America
+UZ	Uzbekistan	Uzbekistan
+UZ	Uzbekistan	Uzbekiston
+UZ	Uzbekistan	Usbekistan
+UZ	Uzbekistan	O‘zbekiston
+UZ	Uzbekistan	Ozbekiston
+UZ	Uzbekistan	O'zbekiston
+UZ	Uzbekistan	Republic of Uzbekistan
+UZ	Uzbekistan	Uzbekstan
+UZ	Uzbekistan	Ozbekistan
+UZ	Uzbekistan	Ouzbékistan
+VA	Holy See	Holy See
+VA	Holy See	Holy See, The
+VA	Holy See	Roman see
+VA	Holy See	Holy see
+VA	Holy See	Holy Seat
+VA	Holy See	Holy seat
+VA	Holy See	Sancta Sedes
+VA	Holy See	Sancta sedes
+VA	Holy See	Santa Sede
+VA	Holy See	Papal see
+VC	Saint Vincent and the Grenadines	Saint Vincent and the Grenadines
+VC	Saint Vincent and the Grenadines	St. Vincent and the Grenadines
+VC	Saint Vincent and the Grenadines	St Vincent and the Grenadines
+VC	Saint Vincent and the Grenadines	Saint Vincent & the Grenadines
+VC	Saint Vincent and the Grenadines	Saint Vincent & The Grenadines
+VC	Saint Vincent and the Grenadines	St. Vincent and The Grenadines
+VC	Saint Vincent and the Grenadines	Saint-Vincent and the Grenadines
+VC	Saint Vincent and the Grenadines	San Vicente y las Granadinas
+VC	Saint Vincent and the Grenadines	St. Vincent & Grenadines
+VC	Saint Vincent and the Grenadines	Saint vincent and the grenadines
+VE	Venezuela	Venezuela
+VE	Venezuela	Venezeula
+VE	Venezuela	Venezuala
+VE	Venezuela	Bolivarian Republic of Venezuela
+VE	Venezuela	VENEZULEA
+VE	Venezuela	VEN
+VE	Venezuela	Venezula
+VE	Venezuela	Republica de Venezuela
+VE	Venezuela	Republica de venezuela
+VE	Venezuela	Venecuela
+VG	British Virgin Islands	British Virgin Islands
+VG	British Virgin Islands	Virgin Islands, British
+VG	British Virgin Islands	VGB
+VG	British Virgin Islands	B.V.I.
+VG	British Virgin Islands	The British Virgin Islands
+VG	British Virgin Islands	British virgin islands
+VG	British Virgin Islands	UK Virgin Islands
+VI	United States Virgin Islands	United States Virgin Islands
+VI	United States Virgin Islands	Virgin Islands, U.S.
+VI	United States Virgin Islands	US Virgin Islands
+VI	United States Virgin Islands	Virgin Islands of the U.S.
+VI	United States Virgin Islands	U. S. Virgin Islands
+VI	United States Virgin Islands	Virgin Islands of the United States
+VI	United States Virgin Islands	American Virgin Islands
+VN	Vietnam	Vietnam
+VN	Vietnam	Socialist Republic of Vietnam
+VN	Vietnam	Viet Nam
+VN	Vietnam	Viet-Nam
+VN	Vietnam	Viêt Nam
+VN	Vietnam	Viêtnam
+VN	Vietnam	Vietnarm
+VN	Vietnam	SRVN
+VN	Vietnam	Yuenan
+VN	Vietnam	VIETNAM
+VU	Vanuatu	Vanuatu
+VU	Vanuatu	Republic of Vanuatu
+VU	Vanuatu	Vanutu
+VU	Vanuatu	Vanautu
+VU	Vanuatu	Vanatua
+VU	Vanuatu	Vuanatu
+VU	Vanuatu	Vanuatua
+VU	Vanuatu	Vanuata
+VU	Vanuatu	Vanatu
+WF	Wallis and Futuna	Wallis and Futuna
+WS	Samoa	Samoa
+WS	Samoa	Western Samoa
+WS	Samoa	West Samoa
+WS	Samoa	Independent State of Samoa
+WS	Samoa	Independent State of Western Samoa
+WS	Samoa	The Independent State of Samoa
+WS	Samoa	IS Samoa
+WS	Samoa	Malosi
+WS	Samoa	Independent state of samoa
+YE	Yemen	Yemen
+YE	Yemen	Yemeni
+YE	Yemen	Republic of Yemen
+YE	Yemen	Al-Yaman
+YE	Yemen	Yemen AR
+YE	Yemen	الجمهوريّة اليمنية
+YE	Yemen	Jemen
+YE	Yemen	Yemen, Republic of
+YE	Yemen	Yemem
+ZA	South Africa	South Africa
+ZA	South Africa	Zuid Africa
+ZA	South Africa	Republic of South Africa
+ZA	South Africa	Suid-Afrika
+ZA	South Africa	Ningizimu Afrika
+ZA	South Africa	Zuidafrika
+ZA	South Africa	S. Africa
+ZA	South Africa	South africa
+ZM	Zambia	Zambia
+ZM	Zambia	Republic of Zambia
+ZM	Zambia	Zambian
+ZM	Zambia	Zamibia
+ZW	Zimbabwe	Zimbabwe
+ZW	Zimbabwe	Republic of Zimbabwe
+ZW	Zimbabwe	Republic Zimbabwe
+ZW	Zimbabwe	Zimbabwean
+ZW	Zimbabwe	ZWE
+ZW	Zimbabwe	Zimbabwae
+ZW	Zimbabwe	Zimbabwian

--- a/wikipedia_resource_generator.py
+++ b/wikipedia_resource_generator.py
@@ -1,0 +1,122 @@
+import os.path
+
+import wikipediaapi
+import pycountry
+
+import re
+import requests
+
+
+# This file only needs to be run in order to generate the lexical resources in the /lexical_resources directory
+
+wiki = wikipediaapi.Wikipedia('en')
+
+
+def getredirectsfor(p):
+    # lifted from https://www.mediawiki.org/wiki/API:Redirects
+    S = requests.Session()
+    URL = "https://en.wikipedia.org/w/api.php"
+
+    PARAMS = {
+        "action": "query",
+        "format": "json",
+        "titles": p,
+        "prop": "redirects"
+    }
+
+    R = S.get(url=URL, params=PARAMS)
+    DATA = R.json()
+
+    PAGES = DATA["query"]["pages"]
+
+    out = []
+    for k, v in PAGES.items():
+        for re in v["redirects"]:
+            out.append(re["title"])
+    return out
+
+
+def make_redirects_lexical_resource(filename):
+    with open(filename, "wt") as f:
+        for c in pycountry.countries:
+            print(c)
+            if hasattr(c,"official_name"):
+                o_name = c.official_name
+            else:
+                o_name = c.name
+            page_py = wiki.page(o_name)
+            title = page_py.title
+            displaytitle = page_py.displaytitle
+            twoletter = c.alpha_2
+            print(title, displaytitle)
+            aliases = [displaytitle] + getredirectsfor(displaytitle)
+            for a in aliases:
+                print("\t".join([twoletter, displaytitle, a]))
+                f.write("\t".join([twoletter, displaytitle, a]) + "\n")
+
+
+
+UNNEEDED_PREFIXES = {
+"administrative subdivisions", "air force", "architecture", "arrondissements and communes", "autonomous province",
+"biodiversity", "capital", "caribbean islands", "caribbean special municipalities", "chief justice", "cockpit",
+"commune", "countries", "departements", "districts and dependencies", "environment", "extreme points",
+"federal states", "greek cypriot administration", "imperial principality", "judiciary",
+"indigenous cultures, kingdoms and ethnic groups", "integral overseas areas", "islamic govermnet", "island area",
+"overseas collectivity", "political history", "proposed state", "quarters", "special municipality", "states",
+"subdivision", "tfyr", "the souvereign military order", "trust territory", "climate", "list", "navy", "regions",
+"collectivity", "districts", "foreign relations", "government", "parishes", "politics", "provinces", "principality",
+"transnational issues", "people", "bibliography", "culture", "languages", "demographics", "economy", "geography",
+"etymology", "history", "name", "administrative divisions", "subdivisions", "military"}
+
+
+def extraneous(s:str, displaytitle=""):
+    # some of these are redundant because of dev process and showing working.
+    if re.match(".*\Ws$", s):
+        return True
+    if s.startswith(displaytitle + "/"):
+        return True
+    if s.startswith("ISO "):
+        return True
+    if "/" in s:
+        return True
+    if " in " in s:
+        return True
+    if " of " in s:
+        #some are needed eg "Kingdom of X" whereas some are not eg "Demographics of X".
+        before_of = re.sub(" of .*", "", s)
+        # we print this then we  $cat x | sort | uniq -c | sort -h | cut -c9-
+        if before_of.lower() in UNNEEDED_PREFIXES:
+            return True
+    for prefix in ["draft:" , "national office"]:
+        if s.lower().startswith(prefix):
+            return True
+
+    for suffix in ["legends", "cultural practices", "news agency", "facts", "culture", "people", "goods",
+                   "(country)", "(state)", "(song)", "(disambiguation)", "(nation)", "(island)"]:
+        if s.lower().endswith(suffix):
+            return True
+
+    if re.search("\d+", s): # years, mainly
+            return True
+
+    if re.search("\(", s): # years, mainly
+            return True
+
+    return False
+
+
+#################################
+
+if not os.path.exists("src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.tab"):
+    make_redirects_lexical_resource("src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.tab")
+
+with open("src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.tab", "rt") as f_in:
+    with open("src/pycountry/lexical_resources/existingcountries_wikipedia_redirects.cleaned.tab", "wt") as f_out:
+        for line in f_in:
+            [twoletter, displaytitle, alias] = line.strip().split("\t")
+            rv = extraneous(alias, displaytitle)
+            if rv:
+                print("ignoring '{}'".format(alias))
+            else:
+                f_out.write(line)
+


### PR DESCRIPTION
Addition of lexical resource derived from wikipedia string-matching. 

Script to generate the lexical resource is included; has dependency on wikipedia-api package, though this is not required merely to use the prebuild resource (included)

Added matching routine that takes advantage of the lexical resource. The lexical resource is not case-or-accent normalised in case it will become useful at a future time to take advantage of case-variants in scoring matches.