### PR TITLE
Trigger lazy-loading when accessing `countries.data_class`

### DIFF
--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -62,7 +62,7 @@ class Database:
         self.index_names = set()
         self.indices = {}
 
-        self.data_class = type(
+        self._data_class = type(
             self.data_class_name, (self.data_class_base,), {}
         )
 
@@ -70,7 +70,7 @@ class Database:
             tree = json.load(f)
 
         for entry in tree[self.root_key]:
-            obj = self.data_class(**entry)
+            obj = self._data_class(**entry)
             self.objects.append(obj)
             # Inject into index.
             for key, value in entry.items():
@@ -91,6 +91,11 @@ class Database:
         self._is_loaded = True
 
     # Public API
+
+    @property
+    @lazy_load
+    def data_class(self):
+        return self._data_class
 
     @lazy_load
     def __iter__(self):

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -14,6 +14,12 @@ def logging():
     logging.basicConfig(level=logging.DEBUG)
 
 
+def test_typing():
+    # data_class must be available before data is accessed,
+    # so that it can be used on typing annotations
+    country: pycountry.countries.data_class
+    country = pycountry.countries.get(alpha_2="BR")
+
 def test_country_list():
     assert len(pycountry.countries) == 249
     assert isinstance(list(pycountry.countries)[0], pycountry.db.Data)


### PR DESCRIPTION
I'm adding a pycountry field into my dataclass, and it is crashing because
the class is defined in the lazy-loading part which hasn't yet been triggered
during type declarations.

This commit modified this library so that the lazy-loading is triggered when accessing `countries.data_class` (and friends)
