### PR TITLE
Update ISO-3166-2 GT 

### DIFF
--- a/src/pycountry/databases/iso3166-2.json
+++ b/src/pycountry/databases/iso3166-2.json
@@ -9373,112 +9373,112 @@
       "type": "Administrative region"
     },
     {
-      "code": "GT-AV",
+      "code": "GT-16",
       "name": "Alta Verapaz",
       "type": "Department"
     },
     {
-      "code": "GT-BV",
+      "code": "GT-15",
       "name": "Baja Verapaz",
       "type": "Department"
     },
     {
-      "code": "GT-CM",
+      "code": "GT-04",
       "name": "Chimaltenango",
       "type": "Department"
     },
     {
-      "code": "GT-CQ",
+      "code": "GT-20",
       "name": "Chiquimula",
       "type": "Department"
     },
     {
-      "code": "GT-ES",
+      "code": "GT-05",
       "name": "Escuintla",
       "type": "Department"
     },
     {
-      "code": "GT-GU",
+      "code": "GT-01",
       "name": "Guatemala",
       "type": "Department"
     },
     {
-      "code": "GT-HU",
+      "code": "GT-13",
       "name": "Huehuetenango",
       "type": "Department"
     },
     {
-      "code": "GT-IZ",
+      "code": "GT-18",
       "name": "Izabal",
       "type": "Department"
     },
     {
-      "code": "GT-JA",
+      "code": "GT-21",
       "name": "Jalapa",
       "type": "Department"
     },
     {
-      "code": "GT-JU",
+      "code": "GT-22",
       "name": "Jutiapa",
       "type": "Department"
     },
     {
-      "code": "GT-PE",
+      "code": "GT-17",
       "name": "Petén",
       "type": "Department"
     },
     {
-      "code": "GT-PR",
+      "code": "GT-02",
       "name": "El Progreso",
       "type": "Department"
     },
     {
-      "code": "GT-QC",
+      "code": "GT-14",
       "name": "Quiché",
       "type": "Department"
     },
     {
-      "code": "GT-QZ",
+      "code": "GT-09",
       "name": "Quetzaltenango",
       "type": "Department"
     },
     {
-      "code": "GT-RE",
+      "code": "GT-11",
       "name": "Retalhuleu",
       "type": "Department"
     },
     {
-      "code": "GT-SA",
+      "code": "GT-03",
       "name": "Sacatepéquez",
       "type": "Department"
     },
     {
-      "code": "GT-SM",
+      "code": "GT-12",
       "name": "San Marcos",
       "type": "Department"
     },
     {
-      "code": "GT-SO",
+      "code": "GT-07",
       "name": "Sololá",
       "type": "Department"
     },
     {
-      "code": "GT-SR",
+      "code": "GT-06",
       "name": "Santa Rosa",
       "type": "Department"
     },
     {
-      "code": "GT-SU",
+      "code": "GT-10",
       "name": "Suchitepéquez",
       "type": "Department"
     },
     {
-      "code": "GT-TO",
+      "code": "GT-08",
       "name": "Totonicapán",
       "type": "Department"
     },
     {
-      "code": "GT-ZA",
+      "code": "GT-19",
       "name": "Zacapa",
       "type": "Department"
     },


### PR DESCRIPTION
On 11-25-2021 the country codes for the Guatemala (GT) were updated.  https://www.iso.org/obp/ui/#iso:code:3166:GT