### PR TITLE
Adding updated GT ISO3166-2 subdivision codes

### DIFF
--- a/src/pycountry/databases/iso3166-2.json
+++ b/src/pycountry/databases/iso3166-2.json
@@ -9609,113 +9609,113 @@
       "type": "Administrative region"
     },
     {
-      "code": "GT-AV",
-      "name": "Alta Verapaz",
-      "type": "Department"
-    },
-    {
-      "code": "GT-BV",
-      "name": "Baja Verapaz",
-      "type": "Department"
-    },
-    {
-      "code": "GT-CM",
-      "name": "Chimaltenango",
-      "type": "Department"
-    },
-    {
-      "code": "GT-CQ",
-      "name": "Chiquimula",
-      "type": "Department"
-    },
-    {
-      "code": "GT-ES",
-      "name": "Escuintla",
-      "type": "Department"
-    },
-    {
-      "code": "GT-GU",
+      "code": "GT-01",
       "name": "Guatemala",
       "type": "Department"
     },
     {
-      "code": "GT-HU",
-      "name": "Huehuetenango",
-      "type": "Department"
-    },
-    {
-      "code": "GT-IZ",
-      "name": "Izabal",
-      "type": "Department"
-    },
-    {
-      "code": "GT-JA",
-      "name": "Jalapa",
-      "type": "Department"
-    },
-    {
-      "code": "GT-JU",
-      "name": "Jutiapa",
-      "type": "Department"
-    },
-    {
-      "code": "GT-PE",
-      "name": "Petén",
-      "type": "Department"
-    },
-    {
-      "code": "GT-PR",
+      "code": "GT-02",
       "name": "El Progreso",
       "type": "Department"
     },
     {
-      "code": "GT-QC",
-      "name": "Quiché",
-      "type": "Department"
-    },
-    {
-      "code": "GT-QZ",
-      "name": "Quetzaltenango",
-      "type": "Department"
-    },
-    {
-      "code": "GT-RE",
-      "name": "Retalhuleu",
-      "type": "Department"
-    },
-    {
-      "code": "GT-SA",
+      "code": "GT-03",
       "name": "Sacatepéquez",
       "type": "Department"
     },
     {
-      "code": "GT-SM",
-      "name": "San Marcos",
+      "code": "GT-04",
+      "name": "Chimaltenango",
       "type": "Department"
     },
     {
-      "code": "GT-SO",
-      "name": "Sololá",
+      "code": "GT-05",
+      "name": "Escuintla",
       "type": "Department"
     },
     {
-      "code": "GT-SR",
+      "code": "GT-06",
       "name": "Santa Rosa",
       "type": "Department"
     },
     {
-      "code": "GT-SU",
-      "name": "Suchitepéquez",
+      "code": "GT-07",
+      "name": "Sololá",
       "type": "Department"
     },
     {
-      "code": "GT-TO",
+      "code": "GT-08",
       "name": "Totonicapán",
       "type": "Department"
     },
     {
-      "code": "GT-ZA",
+      "code": "GT-09",
+      "name": "Quetzaltenango",
+      "type": "Department"
+    },
+    {
+      "code": "GT-10",
+      "name": "Suchitepéquez",
+      "type": "Department"
+    },
+    {
+      "code": "GT-11",
+      "name": "Retalhuleu",
+      "type": "Department"
+    },
+    {
+      "code": "GT-12",
+      "name": "San Marcos",
+      "type": "Department"
+    },
+    {
+      "code": "GT-13",
+      "name": "Huehuetenango",
+      "type": "Department"
+    },
+    {
+      "code": "GT-14",
+      "name": "Quiché",
+      "type": "Department"
+    },
+    {
+      "code": "GT-15",
+      "name": "Baja Verapaz",
+      "type": "Department"
+    },
+    {
+      "code": "GT-16",
+      "name": "Alta Verapaz",
+      "type": "Department"
+    },
+    {
+      "code": "GT-17",
+      "name": "Petén",
+      "type": "Department"
+    },
+    {
+      "code": "GT-18",
+      "name": "Izabal",
+      "type": "Department"
+    },
+    {
+      "code": "GT-19",
       "name": "Zacapa",
+      "type": "Department"
+    },
+    {
+      "code": "GT-20",
+      "name": "Chiquimula",
+      "type": "Department"
+    },
+    {
+      "code": "GT-21",
+      "name": "Jalapa",
+      "type": "Department"
+    },
+    {
+      "code": "GT-22",
+      "name": "Jutiapa",
       "type": "Department"
     },
     {


### PR DESCRIPTION
As of Nov 2021 the ISO has changed the 3166-2 codes for **Guatemala** (**GT**) from 2 letters to 2 numbers, for example the code for the department of San Marcos was previously **GT-SM** but has been updated to **GT-12**. In the src/pycountry/databases/iso3166-2.json file I've gone ahead and added the updated codes.

Sources:
https://www.iso.org/obp/ui/#iso:code:3166:GT
https://en.wikipedia.org/wiki/ISO_3166-2:GT