### PR TITLE
Drop Python 3.6, add Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-  - "3.6"      # current detault Python on Travis CI
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10-dev"  # 3.10 development branch
+  - "3.10"
+  - "3.11"
+  - "3.11-dev"
   - "nightly"  # nightly build
 
 install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 80
-target-version = ['py36', 'py37', 'py38']
 
 [tool.isort]
 profile = "black"
@@ -23,11 +22,11 @@ classifiers = [
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Internationalization",
         "Topic :: Software Development :: Localization"
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310,311}
 
 [testenv]
-deps = pytest
-   pytest-cov
-commands = py.test
+deps =
+    pytest
+    pytest-cov
+commands = pytest


### PR DESCRIPTION
Python 3.6 has not been supported for  a while now, so it should be removed from the Trove classifiers. This was also removed from `.travis.yml` (if relevant/enabled). Python 3.7 should be removed mid-2023.

Add Python 3.11, which was released October 2022.