### PR TITLE
add check for non-ascii chars before removing accents

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -26,10 +26,13 @@ LOCALES_DIR = resource_filename("pycountry", "locales")
 DATABASE_DIR = resource_filename("pycountry", "databases")
 
 
-def remove_accents(input_str):
-    # Borrowed from https://stackoverflow.com/a/517974/1509718
-    nfkd_form = unicodedata.normalize("NFKD", input_str)
-    return "".join([c for c in nfkd_form if not unicodedata.combining(c)])
+def remove_accents(input_str: str):
+    output_str = input_str
+    if not input_str.isascii():
+        # Borrowed from https://stackoverflow.com/a/517974/1509718
+        nfkd_form = unicodedata.normalize("NFKD", input_str)
+        output_str = "".join([c for c in nfkd_form if not unicodedata.combining(c)])
+    return output_str
 
 
 class ExistingCountries(pycountry.db.Database):


### PR DESCRIPTION
Performance improvement to skip running `remove_accents` if the input string already contains only ascii characters.

![Screenshot 2023-07-14 at 10 35 06](https://github.com/flyingcircusio/pycountry/assets/17230030/2d695470-77cd-46cf-aed2-67ccf235a260)
