### PR TITLE
Fix/code quality improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,20 @@ line-length = 80
 
 [tool.ruff.lint]
 select = [
-  "E4",
-  "E7",
-  "E9",
-  "F",
-  "I",
+  "E",      # pycodestyle errors
+  "W",      # pycodestyle warnings
+  "F",      # Pyflakes
+  "I",      # isort
+  "UP",     # pyupgrade
+  "B",      # flake8-bugbear
+  "C4",     # flake8-comprehensions
+  "SIM",    # flake8-simplify
+  "RUF",    # Ruff-specific rules
+]
+ignore = [
+  "E501",   # line too long (handled by formatter)
+  "B018",   # "useless expression" - false positive for pytest.raises() assertions
+            # where we intentionally access attributes to trigger exceptions
 ]
 
 [tool.codespell]

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -92,8 +92,12 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
                         break
 
         # Prio 4: partial matches on subdivision names
+        # Exclude subdivisions already counted in Prio 2 to avoid double-counting
+        matched_subdivision_codes = {s.code for s in matching_subdivisions}
         partial_match_subdivisions = subdivisions.partial_match(query)
         for candidate in partial_match_subdivisions:
+            if candidate.code in matched_subdivision_codes:
+                continue
             v = candidate._fields.get("name")
             if v is not None:
                 v = remove_accents(v.lower())

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -1,10 +1,11 @@
 """pycountry"""
 
+import contextlib
 import os.path
 import unicodedata
 from importlib import metadata as _importlib_metadata
 from importlib import resources as _importlib_resources
-from typing import cast
+from typing import ClassVar, cast
 
 import pycountry.db
 
@@ -57,10 +58,8 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
             results[country.alpha_2] += points
 
         # Prio 1: exact matches on country names
-        try:
+        with contextlib.suppress(LookupError):
             add_result(self.lookup(query), 50)
-        except LookupError:
-            pass
 
         # Prio 2: exact matches on subdivision names
         matching_subdivisions = subdivisions.match(query)
@@ -139,7 +138,9 @@ class Currencies(pycountry.db.Database[pycountry.db.Data]):
 class Languages(pycountry.db.Database[pycountry.db.Data]):
     """Provides access to an ISO 639-1/2T/3 database (Languages)."""
 
-    no_index = ["status", "scope", "type", "inverted_name", "common_name"]
+    no_index: ClassVar[list[str]] = [
+        "status", "scope", "type", "inverted_name", "common_name"
+    ]
 
     data_class = "Language"
     root_key = "639-3"
@@ -155,10 +156,7 @@ class LanguageFamilies(pycountry.db.Database[pycountry.db.Data]):
 
 class SubdivisionHierarchy(pycountry.db.Data):
     def __init__(self, **kw):
-        if "parent" in kw:
-            kw["parent_code"] = kw["parent"]
-        else:
-            kw["parent_code"] = None
+        kw["parent_code"] = kw.get("parent")
         super().__init__(**kw)
         self.country_code = self.code.split("-")[0]
         if self.parent_code is not None:
@@ -184,8 +182,8 @@ class Subdivisions(pycountry.db.Database[SubdivisionHierarchy]):
     # the country!
 
     data_class = SubdivisionHierarchy
-    no_index = ["name", "parent_code", "parent", "type"]
-    special_index = ["country_code"]
+    no_index: ClassVar[list[str]] = ["name", "parent_code", "parent", "type"]
+    special_index: ClassVar[list[str]] = ["country_code"]
     root_key = "3166-2"
 
     def _special_index(self, obj, key):
@@ -201,12 +199,15 @@ class Subdivisions(pycountry.db.Database[SubdivisionHierarchy]):
     def get(self, **kw):
         default = kw.setdefault("default", None)
         subdivisions = super().get(**kw)
-        if subdivisions is default and "country_code" in kw:
-            # This handles the case where we know about a country but there
-            # are no subdivisions: we return an empty list in this case
-            # (sticking to the expected type here) instead of None.
-            if countries.get(alpha_2=kw["country_code"]) is not None:
-                return []
+        # This handles the case where we know about a country but there
+        # are no subdivisions: we return an empty list in this case
+        # (sticking to the expected type here) instead of None.
+        if (
+            subdivisions is default
+            and "country_code" in kw
+            and countries.get(alpha_2=kw["country_code"]) is not None
+        ):
+            return []
         return subdivisions
 
     def match(self, query):

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -49,13 +49,17 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
     def search_fuzzy(self, query: str) -> list[pycountry.db.Country]:
         query = remove_accents(query.strip().lower())
 
-        # A country-code to points mapping for later sorting countries
-        # based on the query's matching incidence.
-        results: dict[str, int] = {}
+        # Map country objects to points for sorting. We use id() as the key
+        # because alpha_2 codes can be reused (e.g., historic countries
+        # Czechoslovakia and Serbia both have alpha_2='CS').
+        results: dict[int, int] = {}
+        country_by_id: dict[int, pycountry.db.Country] = {}
 
         def add_result(country: "pycountry.db.Country", points: int) -> None:
-            results.setdefault(country.alpha_2, 0)
-            results[country.alpha_2] += points
+            key = id(country)
+            results.setdefault(key, 0)
+            results[key] += points
+            country_by_id[key] = country
 
         # Prio 1: exact matches on country names
         with contextlib.suppress(LookupError):
@@ -107,12 +111,15 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
         if not results:
             raise LookupError(query)
 
+        # Sort by points (descending), then by alpha_2 code (ascending) for
+        # stable results. Use the stored country objects directly instead of
+        # looking up by alpha_2, which can be ambiguous for historic countries.
         sorted_results = [
-            self.get(alpha_2=x[0])
-            # sort by points first, by alpha2 code second, and to ensure stable
-            # results the negative value allows us to sort reversely on the
-            # points but ascending on the country code.
-            for x in sorted(results.items(), key=lambda x: (-x[1], x[0]))
+            country_by_id[key]
+            for key, _ in sorted(
+                results.items(),
+                key=lambda x: (-x[1], country_by_id[x[0]].alpha_2),
+            )
         ]
         return cast(list[pycountry.db.Country], sorted_results)
 

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -150,7 +150,11 @@ class Languages(pycountry.db.Database[pycountry.db.Data]):
     """Provides access to an ISO 639-1/2T/3 database (Languages)."""
 
     no_index: ClassVar[list[str]] = [
-        "status", "scope", "type", "inverted_name", "common_name"
+        "status",
+        "scope",
+        "type",
+        "inverted_name",
+        "common_name",
     ]
 
     data_class = "Language"

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -63,10 +63,8 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
             pass
 
         # Prio 2: exact matches on subdivision names
-        match_subdivions = pycountry.Subdivisions.match(
-            self=subdivisions, query=query
-        )
-        for candidate in match_subdivions:
+        matching_subdivisions = subdivisions.match(query)
+        for candidate in matching_subdivisions:
             add_result(candidate.country, 49)
 
         # Prio 3: partial matches on country names
@@ -95,14 +93,13 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
                         break
 
         # Prio 4: partial matches on subdivision names
-        partial_match_subdivisions = pycountry.Subdivisions.partial_match(
-            self=subdivisions, query=query
-        )
+        partial_match_subdivisions = subdivisions.partial_match(query)
         for candidate in partial_match_subdivisions:
             v = candidate._fields.get("name")
-            v = remove_accents(v.lower())
-            if query in v:
-                add_result(candidate.country, max([1, 5 - v.find(query)]))
+            if v is not None:
+                v = remove_accents(v.lower())
+                if query in v:
+                    add_result(candidate.country, max([1, 5 - v.find(query)]))
 
         if not results:
             raise LookupError(query)
@@ -125,21 +122,21 @@ class HistoricCountries(ExistingCountries):
     root_key = "3166-3"
 
 
-class Scripts(pycountry.db.Database):
+class Scripts(pycountry.db.Database[pycountry.db.Data]):
     """Provides access to an ISO 15924 database (Scripts)."""
 
     data_class = "Script"
     root_key = "15924"
 
 
-class Currencies(pycountry.db.Database):
+class Currencies(pycountry.db.Database[pycountry.db.Data]):
     """Provides access to an ISO 4217 database (Currencies)."""
 
     data_class = "Currency"
     root_key = "4217"
 
 
-class Languages(pycountry.db.Database):
+class Languages(pycountry.db.Database[pycountry.db.Data]):
     """Provides access to an ISO 639-1/2T/3 database (Languages)."""
 
     no_index = ["status", "scope", "type", "inverted_name", "common_name"]
@@ -148,7 +145,7 @@ class Languages(pycountry.db.Database):
     root_key = "639-3"
 
 
-class LanguageFamilies(pycountry.db.Database):
+class LanguageFamilies(pycountry.db.Database[pycountry.db.Data]):
     """Provides access to an ISO 639-5 database
     (Language Families and Groups)."""
 
@@ -181,7 +178,7 @@ class SubdivisionHierarchy(pycountry.db.Data):
         return subdivisions.get(code=self.parent_code)
 
 
-class Subdivisions(pycountry.db.Database):
+class Subdivisions(pycountry.db.Database[SubdivisionHierarchy]):
     # Note: subdivisions can be hierarchical to other subdivisions. The
     # parent_code attribute is related to other subdivisions, *not*
     # the country!
@@ -231,15 +228,16 @@ class Subdivisions(pycountry.db.Database):
     def partial_match(self, query):
         query = remove_accents(query.strip().lower())
         matching_candidates = []
-        for candidate in subdivisions:
+        for candidate in self:
             v = candidate._fields.get("name")
-            v = remove_accents(v.lower())
-            if query in v:
-                matching_candidates.append(candidate)
+            if v is not None:
+                v = remove_accents(v.lower())
+                if query in v:
+                    matching_candidates.append(candidate)
 
         return matching_candidates
 
-    def search_fuzzy(self, query: str) -> list[type["Subdivisions"]]:
+    def search_fuzzy(self, query: str) -> list[SubdivisionHierarchy]:
         query = remove_accents(query.strip().lower())
 
         # A Subdivision's code to points mapping for later sorting subdivisions
@@ -261,9 +259,10 @@ class Subdivisions(pycountry.db.Database):
         partial_match_subdivisions = self.partial_match(query)
         for candidate in partial_match_subdivisions:
             v = candidate._fields.get("name")
-            v = remove_accents(v.lower())
-            if query in v:
-                add_result(candidate, max([1, 5 - v.find(query)]))
+            if v is not None:
+                v = remove_accents(v.lower())
+                if query in v:
+                    add_result(candidate, max([1, 5 - v.find(query)]))
 
         if not results:
             raise LookupError(query)

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -35,6 +35,19 @@ class Data:
         for field in self._fields:
             yield field, getattr(self, field)
 
+    def __copy__(self):
+        """Support for copy.copy() - creates a shallow copy."""
+        return self.__class__(**self._fields.copy())
+
+    def __deepcopy__(self, memo):
+        """Support for copy.deepcopy() - creates a deep copy."""
+        from copy import deepcopy
+
+        new_fields = deepcopy(self._fields, memo)
+        result = self.__class__(**new_fields)
+        memo[id(self)] = result
+        return result
+
 
 class Country(Data):
     pass

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -24,7 +24,9 @@ class Data:
 
     def __repr__(self) -> str:
         cls_name = self.__class__.__name__
-        fields = ", ".join(f"{k}={v!r}" for k, v in sorted(self._fields.items()))
+        fields = ", ".join(
+            f"{k}={v!r}" for k, v in sorted(self._fields.items())
+        )
         return f"{cls_name}({fields})"
 
     def __dir__(self) -> list[str]:

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -1,8 +1,9 @@
+import functools
 import json
 import logging
 import threading
 from collections.abc import Callable, Iterator
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, ClassVar, Generic, TypeVar, cast
 
 logger = logging.getLogger("pycountry.db")
 
@@ -23,7 +24,7 @@ class Data:
 
     def __repr__(self) -> str:
         cls_name = self.__class__.__name__
-        fields = ", ".join("%s=%r" % i for i in sorted(self._fields.items()))
+        fields = ", ".join(f"{k}={v!r}" for k, v in sorted(self._fields.items()))
         return f"{cls_name}({fields})"
 
     def __dir__(self) -> list[str]:
@@ -47,6 +48,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def lazy_load(f: F) -> F:
+    @functools.wraps(f)
     def load_if_needed(self, *args, **kw):
         if not self._is_loaded:
             with self._load_lock:
@@ -60,15 +62,17 @@ T = TypeVar("T", bound=Data)
 
 
 class Database(Generic[T]):
-    data_class: type | str
-    root_key: str | None = None
-    no_index: list[str] = []
-    special_index: list[str] = []
+    data_class: ClassVar[type | str]
+    root_key: ClassVar[str | None] = None
+    no_index: ClassVar[list[str]] = []
+    special_index: ClassVar[list[str]] = []
 
     def __init__(self, filename: str) -> None:
         self.filename = filename
         self._is_loaded = False
         self._load_lock = threading.Lock()
+        self.objects: list[T] = []
+        self.indices: dict[str, dict[str, T]] = {}
 
         if isinstance(self.data_class, str):
             self.factory = type(self.data_class, (Data,), {})
@@ -99,9 +103,9 @@ class Database(Generic[T]):
             value = value.lower()
             if value in index:
                 logger.debug(
-                    "%s %r already taken in index %r and will be "
-                    "ignored. This is an error in the databases."
-                    % (self.factory.__name__, value, key)
+                    f"{self.factory.__name__} {value!r} already taken in "
+                    f"index {key!r} and will be ignored. "
+                    "This is an error in the databases."
                 )
             index[value] = obj
 
@@ -213,4 +217,4 @@ class Database(Generic[T]):
                 if v.lower() == value:
                     return candidate
 
-        raise LookupError("Could not find a record for %r" % value)
+        raise LookupError(f"Could not find a record for {value!r}")

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -88,6 +88,11 @@ def test_historic_country_fuzzy_search(countries):
     assert len(results) == 1
     assert results[0] == pycountry.historic_countries.get(alpha_4="BUMM")
 
+    # issue #242: Czechoslovakia should return Czechoslovakia, not Serbia.
+    # Both share alpha_2='CS', but searching by name should find the right one.
+    results = pycountry.historic_countries.search_fuzzy("Czechoslovakia")
+    assert results[0] == pycountry.historic_countries.get(alpha_4="CSHH")
+
 
 def test_germany_has_all_attributes(countries):
     germany = pycountry.countries.get(alpha_2="DE")

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -75,6 +75,13 @@ def test_country_fuzzy_search(countries):
     assert len(results) >= 4
     assert pycountry.countries.get(alpha_2="GB") in results[:4]
 
+    # issue #115, Niger should rank above Nigeria when searching for "niger"
+    # because "Niger" is a more precise match (exact length) than "Nigeria"
+    # which just happens to have a subdivision called "Niger State"
+    results = pycountry.countries.search_fuzzy("niger")
+    assert results[0] == pycountry.countries.get(alpha_2="NE")  # Niger
+    assert pycountry.countries.get(alpha_2="NG") in results  # Nigeria also matches
+
 
 def test_historic_country_fuzzy_search(countries):
     results = pycountry.historic_countries.search_fuzzy("burma")

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -80,7 +80,9 @@ def test_country_fuzzy_search(countries):
     # which just happens to have a subdivision called "Niger State"
     results = pycountry.countries.search_fuzzy("niger")
     assert results[0] == pycountry.countries.get(alpha_2="NE")  # Niger
-    assert pycountry.countries.get(alpha_2="NG") in results  # Nigeria also matches
+    assert (
+        pycountry.countries.get(alpha_2="NG") in results
+    )  # Nigeria also matches
 
 
 def test_historic_country_fuzzy_search(countries):
@@ -195,7 +197,9 @@ def test_languages():
 
 def test_language_families():
     assert len(pycountry.language_families) == 115
-    assert isinstance(next(iter(pycountry.language_families)), pycountry.db.Data)
+    assert isinstance(
+        next(iter(pycountry.language_families)), pycountry.db.Data
+    )
 
     aragonese = pycountry.languages.get(alpha_3="arg")
     assert aragonese.alpha_3 == "arg"

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -26,7 +26,7 @@ def subdivisions():
 
 def test_country_list(countries):
     assert len(pycountry.countries) == 249
-    assert isinstance(list(pycountry.countries)[0], pycountry.db.Data)
+    assert isinstance(next(iter(pycountry.countries)), pycountry.db.Data)
 
 
 def test_country_fuzzy_search(countries):
@@ -117,7 +117,7 @@ def test_country_missing_attribute(countries):
 
 def test_subdivisions_directly_accessible(countries):
     assert len(pycountry.subdivisions) == 5046
-    assert isinstance(list(pycountry.subdivisions)[0], pycountry.db.Data)
+    assert isinstance(next(iter(pycountry.subdivisions)), pycountry.db.Data)
 
     de_st = pycountry.subdivisions.get(code="DE-ST")
     assert de_st.code == "DE-ST"
@@ -145,7 +145,7 @@ def test_query_subdivisions_of_country():
 
 def test_scripts():
     assert len(pycountry.scripts) == 226
-    assert isinstance(list(pycountry.scripts)[0], pycountry.db.Data)
+    assert isinstance(next(iter(pycountry.scripts)), pycountry.db.Data)
 
     latin = pycountry.scripts.get(name="Latin")
     assert latin.alpha_4 == "Latn"
@@ -155,7 +155,7 @@ def test_scripts():
 
 def test_currencies():
     assert len(pycountry.currencies) == 178
-    assert isinstance(list(pycountry.currencies)[0], pycountry.db.Data)
+    assert isinstance(next(iter(pycountry.currencies)), pycountry.db.Data)
 
     argentine_peso = pycountry.currencies.get(alpha_3="ARS")
     assert argentine_peso.alpha_3 == "ARS"
@@ -165,7 +165,7 @@ def test_currencies():
 
 def test_languages():
     assert len(pycountry.languages) == 7923
-    assert isinstance(list(pycountry.languages)[0], pycountry.db.Data)
+    assert isinstance(next(iter(pycountry.languages)), pycountry.db.Data)
 
     aragonese = pycountry.languages.get(alpha_2="an")
     assert aragonese.alpha_2 == "an"
@@ -183,7 +183,7 @@ def test_languages():
 
 def test_language_families():
     assert len(pycountry.language_families) == 115
-    assert isinstance(list(pycountry.language_families)[0], pycountry.db.Data)
+    assert isinstance(next(iter(pycountry.language_families)), pycountry.db.Data)
 
     aragonese = pycountry.languages.get(alpha_3="arg")
     assert aragonese.alpha_3 == "arg"

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -191,6 +191,16 @@ def test_language_families():
 
 
 def test_locales():
+    # Skip if locale files aren't available (e.g., in RPM builds where
+    # LOCALES_DIR may point to system locales with different naming)
+    locale_file = os.path.join(
+        pycountry.LOCALES_DIR, "de", "LC_MESSAGES", "iso3166-1.mo"
+    )
+    if not os.path.exists(locale_file):
+        pytest.skip(
+            f"Locale file not found: {locale_file}. "
+            "LOCALES_DIR may point to system locales."
+        )
     german = gettext.translation(
         "iso3166-1", pycountry.LOCALES_DIR, languages=["de"]
     )

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -527,3 +527,47 @@ def test_subdivisions_with_missing_parents(subdivisions):
         if i.parent_code and not i.parent
     ]
     assert result == []
+
+
+def test_deepcopy_country(countries):
+    """Test that deepcopy works on country objects (fixes issue #222)."""
+    from copy import deepcopy
+
+    usa = pycountry.countries.get(alpha_2="US")
+    usa_copy = deepcopy(usa)
+
+    # Verify it's a different object
+    assert usa_copy is not usa
+    # Verify attributes are preserved
+    assert usa_copy.alpha_2 == usa.alpha_2
+    assert usa_copy.alpha_3 == usa.alpha_3
+    assert usa_copy.name == usa.name
+
+
+def test_shallow_copy_country(countries):
+    """Test that shallow copy works on country objects."""
+    from copy import copy
+
+    germany = pycountry.countries.get(alpha_2="DE")
+    germany_copy = copy(germany)
+
+    # Verify it's a different object
+    assert germany_copy is not germany
+    # Verify attributes are preserved
+    assert germany_copy.alpha_2 == germany.alpha_2
+    assert germany_copy.name == germany.name
+
+
+def test_deepcopy_subdivision(subdivisions):
+    """Test that deepcopy works on subdivision objects."""
+    from copy import deepcopy
+
+    california = pycountry.subdivisions.get(code="US-CA")
+    california_copy = deepcopy(california)
+
+    # Verify it's a different object
+    assert california_copy is not california
+    # Verify attributes are preserved
+    assert california_copy.code == california.code
+    assert california_copy.name == california.name
+    assert california_copy.country_code == california.country_code


### PR DESCRIPTION
## Summary

This PR addresses several open issues and improves overall code quality:

### Bug Fixes

- **#115**: Fixed "Niger" vs "Nigeria" ranking issue where Nigeria incorrectly ranked first when searching "niger". Root cause was subdivision matches being double-counted in Prio 2 and Prio 4.

- **#222**: Added `__copy__` and `__deepcopy__` support to `Data` objects, enabling `copy.copy()` and `copy.deepcopy()` to work correctly.

- **#234**: Fixed `test_locales` to skip gracefully when locale files aren't available (e.g., in RPM builds where `LOCALES_DIR` points to system locales).

- **#242**: Fixed "Czechoslovakia" returning "Serbia" in historic country fuzzy search. Root cause was both countries sharing `alpha_2='CS'`, causing result collisions. Now uses unique object IDs for result tracking.

### Code Quality Improvements

- Converted `%` string formatting to f-strings
- Added `@functools.wraps` to decorators
- Improved type annotations with `ClassVar` and generics
- Expanded Ruff linting rules (E, W, F, I, UP, B, C4, SIM, RUF)
- Fixed various Ruff violations (SIM102, SIM105, SIM401, RUF012, RUF015)

## Testing

All existing tests pass. Added new tests for:
- `copy.copy()` and `copy.deepcopy()` on country/subdivision objects
- Niger ranking in fuzzy search
- Czechoslovakia in historic country fuzzy search