### PR TITLE
Fix Data.__getattr__ infinite recursion and search_fuzzy empty-query contract

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -47,6 +47,8 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
 
     def search_fuzzy(self, query: str) -> list[pycountry.db.Country]:
         query = remove_accents(query.strip().lower())
+        if not query:
+            raise LookupError(query)
 
         # A country-code to points mapping for later sorting countries
         # based on the query's matching incidence.
@@ -241,6 +243,8 @@ class Subdivisions(pycountry.db.Database):
 
     def search_fuzzy(self, query: str) -> list[type["Subdivisions"]]:
         query = remove_accents(query.strip().lower())
+        if not query:
+            raise LookupError(query)
 
         # A Subdivision's code to points mapping for later sorting subdivisions
         # based on the query's matching incidence.

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -12,8 +12,14 @@ class Data:
         self._fields = fields
 
     def __getattr__(self, key: str) -> str:
-        if key in self._fields:
-            return self._fields[key]
+        # Use object.__getattribute__ to avoid infinite recursion when _fields
+        # is not yet set (e.g. during copy/pickle reconstruction).
+        try:
+            fields = object.__getattribute__(self, "_fields")
+        except AttributeError:
+            raise AttributeError(key)
+        if key in fields:
+            return fields[key]
         raise AttributeError(key)
 
     def __setattr__(self, key: str, value: str) -> None:

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -527,3 +527,32 @@ def test_subdivisions_with_missing_parents(subdivisions):
         if i.parent_code and not i.parent
     ]
     assert result == []
+
+
+def test_country_deepcopy(countries):
+    """Data objects must survive copy.deepcopy without RecursionError (#222)."""
+    from copy import copy, deepcopy
+
+    us = pycountry.countries.get(alpha_2="US")
+    us_deep = deepcopy(us)
+    assert us_deep.alpha_2 == "US"
+    assert us_deep.name == "United States"
+
+    us_shallow = copy(us)
+    assert us_shallow.alpha_2 == "US"
+
+
+def test_country_search_fuzzy_empty_query_raises(countries):
+    """search_fuzzy on a blank query must raise LookupError, not return all (#206)."""
+    with pytest.raises(LookupError):
+        pycountry.countries.search_fuzzy("")
+    with pytest.raises(LookupError):
+        pycountry.countries.search_fuzzy("   ")
+
+
+def test_subdivision_search_fuzzy_empty_query_raises(subdivisions):
+    """search_fuzzy on a blank query must raise LookupError, not return all (#206)."""
+    with pytest.raises(LookupError):
+        pycountry.subdivisions.search_fuzzy("")
+    with pytest.raises(LookupError):
+        pycountry.subdivisions.search_fuzzy("   ")


### PR DESCRIPTION
## Problem

Two independent but both long-standing bugs in `pycountry`:

### 1. `copy.copy` / `copy.deepcopy` raises `RecursionError` (closes #222)

```python
from copy import deepcopy
import pycountry
deepcopy(pycountry.countries.get(alpha_2='US'))
# RecursionError: maximum recursion depth exceeded
```

**Root cause:** `Data.__getattr__` accesses `self._fields` via normal Python attribute lookup. During copy/pickle reconstruction Python creates a blank instance (via `object.__new__`) and then restores state. Before `_fields` is written into `__dict__`, any attribute access triggers `__getattr__`, which evaluates `self._fields` — which triggers `__getattr__('_fields')` — infinite recursion.

**Fix:** Use `object.__getattribute__(self, "_fields")` (with an `AttributeError` guard) to read `_fields` directly, bypassing `__getattr__`.

### 2. `search_fuzzy("")` returns all records instead of raising `LookupError` (closes #206)

```python
import pycountry
pycountry.countries.search_fuzzy('')  # returns all 249 countries — wrong
pycountry.subdivisions.search_fuzzy('   ')  # returns all subdivisions — wrong
```

**Root cause:** After `strip().lower()`, an empty string matches every candidate via the `query in v` substring test (empty string is a substring of everything). The `LookupError` guard at the bottom never fires.

**Fix:** Raise `LookupError` immediately when the normalised query is empty.

## Changes

- `src/pycountry/db.py`: fix `Data.__getattr__` to use `object.__getattribute__`
- `src/pycountry/__init__.py`: add blank-query guard in `ExistingCountries.search_fuzzy` and `Subdivisions.search_fuzzy`
- `src/pycountry/tests/test_general.py`: three new tests covering deepcopy, shallow copy, and empty search_fuzzy on both databases

## Tests

```
56 passed in 1.35s  (53 pre-existing + 3 new)
Coverage: 98.33%
```

---

This pull request was prepared with the assistance of AI, under my direction and review.